### PR TITLE
Use a much longer timeout on popping queue jobs

### DIFF
--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -70,7 +70,7 @@ class Worker(multiprocessing.Process):
         # Tell master process that we are not processing anything.
         self.tell_master(None, False)
 
-        job = backend.dequeue(self.queue, 300)
+        job = backend.dequeue(self.queue, 30*60)
         if job is None:
             return
 

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -70,7 +70,7 @@ class Worker(multiprocessing.Process):
         # Tell master process that we are not processing anything.
         self.tell_master(None, False)
 
-        job = backend.dequeue(self.queue, 1)
+        job = backend.dequeue(self.queue, 300)
         if job is None:
             return
 


### PR DESCRIPTION
Rather than poking Redis every second, we can now `BLPOP` every 5 minutes. This has no effect on queue capacity or latency, but means much Redis spam from idle workers.

- [ ] @tavva 
- [x] @tomokas 
- [x] @danpalmer 
- [x] @cbaines 
- [ ] @knaveofdiamonds 