### PR TITLE
Restart idle workers

### DIFF
--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -71,7 +71,8 @@ class Worker(multiprocessing.Process):
         self.log.info("Exiting")
 
     def idle_time_reached(self, time_item_last_processed):
-        return datetime.datetime.utcnow() - time_item_last_processed > datetime.timedelta(minutes=30)
+        return datetime.datetime.utcnow() - time_item_last_processed \
+            > datetime.timedelta(minutes=30)
 
     def process(self, backend):
         self.log.debug("Checking backend for items")

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -58,7 +58,13 @@ class Worker(multiprocessing.Process):
 
         time_item_last_processed = datetime.datetime.utcnow()
 
-        while self.running.value and not self.idle_time_reached(time_item_last_processed):
+        while True:
+            if not self.running.value:
+                break
+
+            if self.idle_time_reached(time_item_last_processed):
+                break
+
             try:
                 item_processed = self.process(backend)
 

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -83,8 +83,9 @@ class Worker(multiprocessing.Process):
         self.log.info("Exiting")
 
     def idle_time_reached(self, time_item_last_processed):
-        return datetime.datetime.utcnow() - time_item_last_processed \
-            > datetime.timedelta(minutes=30)
+        idle_time = datetime.datetime.utcnow() - time_item_last_processed
+
+        return idle_time > datetime.timedelta(minutes=30)
 
     def process(self, backend):
         self.log.debug("Checking backend for items")

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -64,9 +64,11 @@ class Worker(multiprocessing.Process):
                 break
 
             if self.idle_time_reached(time_item_last_processed):
+                self.log.info("Exiting due to reaching idle time limit")
                 break
 
             if item_count > 1000:
+                self.log.info("Exiting due to reaching item limit")
                 break
 
             try:

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -56,14 +56,14 @@ class Worker(multiprocessing.Process):
         backend = get_backend()
         self.log.info("Loaded backend %s", backend)
 
-        time_item_last_processed = datetime.datetime.now()
+        time_item_last_processed = datetime.datetime.utcnow()
 
         while self.running.value and not self.idle_time_reached(time_item_last_processed):
             try:
                 item_processed = self.process(backend)
 
                 if item_processed:
-                    time_item_last_processed = datetime.datetime.now()
+                    time_item_last_processed = datetime.datetime.utcnow()
 
             except KeyboardInterrupt:
                 sys.exit(1)
@@ -71,7 +71,7 @@ class Worker(multiprocessing.Process):
         self.log.info("Exiting")
 
     def idle_time_reached(self, time_item_last_processed):
-        return datetime.datetime.now() - time_item_last_processed > datetime.timedelta(minutes=30)
+        return datetime.datetime.utcnow() - time_item_last_processed > datetime.timedelta(minutes=30)
 
     def process(self, backend):
         self.log.debug("Checking backend for items")

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -72,7 +72,7 @@ class Worker(multiprocessing.Process):
 
         job = backend.dequeue(self.queue, 15)
         if job is None:
-            return
+            return False
 
         # Update master what we are doing
         self.tell_master(
@@ -97,6 +97,8 @@ class Worker(multiprocessing.Process):
             except AttributeError:
                 pass
             connections[x].close()
+
+        return True
 
     def tell_master(self, timeout, sigkill_on_stop):
         self.back_channel.put((

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -3,6 +3,7 @@ import sys
 import signal
 import logging
 import datetime
+import itertools
 import multiprocessing
 
 from django.db import connections, transaction
@@ -58,11 +59,14 @@ class Worker(multiprocessing.Process):
 
         time_item_last_processed = datetime.datetime.utcnow()
 
-        while True:
+        for item_count in itertools.count():
             if not self.running.value:
                 break
 
             if self.idle_time_reached(time_item_last_processed):
+                break
+
+            if item_count > 1000:
                 break
 
             try:


### PR DESCRIPTION
This will reduce the memory usage, by restarting idle workers after 30 minutes.