### PR TITLE
Daemonize

### DIFF
--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -2,8 +2,8 @@ import os
 import logging
 import optparse
 
-from django.db import models
 from django.utils.daemonize import become_daemon
+from django.apps import apps
 from django.core.management.base import NoArgsCommand
 
 from ...utils import get_backend, get_middleware, configure_logging
@@ -61,7 +61,7 @@ class Command(NoArgsCommand):
         # Ensure children will be able to import most things, but also try and
         # save memory by importing as much as possible before the fork() as it
         # has copy-on-write semantics.
-        models.get_models()
+        apps.get_models()
         log.info("Loaded models")
 
         # fork() only after we have started enough to catch failure, including

--- a/django_lightweight_queue/utils.py
+++ b/django_lightweight_queue/utils.py
@@ -14,6 +14,9 @@ def configure_logging(level, format, filename):
     nicely with logrotate and similar tools.
 
     We also unconditionally remove all existing handlers.
+
+    Returns the file handle of the log file so that we can pass this on to a
+    daemon process.
     """
 
     logging.root.handlers = []
@@ -28,6 +31,8 @@ def configure_logging(level, format, filename):
 
     if level is not None:
         logging.root.setLevel(level)
+
+    return handler.stream.fileno()
 
 @lru_cache()
 def get_path(path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+daemonize

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+Django>=1.9.0,<1.10.0
 daemonize
+redis


### PR DESCRIPTION
#### Changes

Django 1.9 removes FastCGI support, and with it an undocumented utility `become_daemon` that DLQ depended on.

This change uses the `daemonize` library to replace the functionality.

Daemonize: [documentation](http://daemonize.readthedocs.org/en/latest/?badge=latest#), [code](https://github.com/thesharp/daemonize), [PyPI](https://pypi.python.org/pypi/daemonize/).

Original Django implementation: https://raw.githubusercontent.com/django/django/a1f5bafac51f973cc7219d3b7c96587fe7066920/django/utils/daemonize.py

#### Reviewed

 - [x] @cbaines
 - [x] @prophile
 - [ ] @tavva
 - [ ] @tomokas