### PR TITLE
Run the middleware in the correct order

### DIFF
--- a/django_lightweight_queue/job.py
+++ b/django_lightweight_queue/job.py
@@ -35,7 +35,7 @@ class Job(object):
 
             time_taken = time.time() - start
 
-            for instance in middleware:
+            for instance in reversed(middleware):
                 if hasattr(instance, 'process_result'):
                     instance.process_result(self, result, time_taken)
         except Exception:
@@ -43,7 +43,7 @@ class Job(object):
 
             exc_info = sys.exc_info()
 
-            for instance in middleware:
+            for instance in reversed(middleware):
                 if hasattr(instance, 'process_exception'):
                     try:
                         instance.process_exception(self, time_taken, *exc_info)


### PR DESCRIPTION
#### Changes
When DLQ runs middleware pre-job-run, it iterates over the middleware from beginning to end. For correct semantics, when running middleware post-job run, it should iterate in the reverse of that order. 

E.g. consider we have two middlewares running: a transactional middleware and a logging middleware, we want logging to happen before the transaction starts, and after it ends (e.g. so you can log "job finished" once data has actually been written to the database, if you define your middleware as
```
middleware = (
   'logging',
   'transactional',
)
```
without this change, after a job has run, we would log before committing the transaction.

### Reviewed

 - [x] @cbaines
 - [x] @prophile
 - [x] @tavva
 - [ ] @danpalmer
 - [ ] @kulor