### PR TITLE
Reliable queue

### DIFF
--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -4,7 +4,7 @@ def setting(suffix, default):
     return getattr(settings, 'LIGHTWEIGHT_QUEUE_%s' % suffix, default)
 
 WORKERS = setting('WORKERS', {})
-DEFAULT_BACKEND = setting('DEFAULT_BACKEND', 'django_lightweight_queue.backends.synchronous.SynchronousBackend')
+BACKEND = setting('BACKEND', 'django_lightweight_queue.backends.synchronous.SynchronousBackend')
 
 # Allow per-queue overrides of the backend.
 BACKEND_OVERRIDES = setting('BACKEND_OVERRIDES', {})

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -4,7 +4,11 @@ def setting(suffix, default):
     return getattr(settings, 'LIGHTWEIGHT_QUEUE_%s' % suffix, default)
 
 WORKERS = setting('WORKERS', {})
-BACKEND = setting('BACKEND', 'django_lightweight_queue.backends.synchronous.SynchronousBackend')
+DEFAULT_BACKEND = setting('DEFAULT_BACKEND', 'django_lightweight_queue.backends.synchronous.SynchronousBackend')
+
+# Allow per-queue overrides of the backend.
+BACKEND_OVERRIDES = setting('BACKEND_OVERRIDES', {})
+
 MIDDLEWARE = setting('MIDDLEWARE', (
     'django_lightweight_queue.middleware.logging.LoggingMiddleware',
     'django_lightweight_queue.middleware.transaction.TransactionMiddleware',

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -12,6 +12,9 @@ class RedisBackend(object):
             port=app_settings.REDIS_PORT,
         )
 
+    def startup(self, queue):
+        pass
+
     def enqueue(self, job, queue):
         self.client.rpush(self._key(queue), job.to_json())
 

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -26,6 +26,9 @@ class RedisBackend(object):
     def length(self, queue):
         return self.client.llen(self._key(queue))
 
+    def processed_job(self, queue, worker_num, job):
+        pass
+
     def _key(self, queue):
         if app_settings.REDIS_PREFIX:
             return '%s:django_lightweight_queue:%s' % (

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -6,6 +6,9 @@ from ..job import Job
 from .. import app_settings
 
 class RedisBackend(object):
+    """
+    This backend has at-most-once semantics.
+    """
     def __init__(self):
         self.client = redis.Redis(
             host=app_settings.REDIS_HOST,

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -15,7 +15,7 @@ class RedisBackend(object):
     def enqueue(self, job, queue):
         self.client.rpush(self._key(queue), job.to_json())
 
-    def dequeue(self, queue, timeout):
+    def dequeue(self, queue, worker_num, timeout):
         try:
             _, data = self.client.blpop(self._key(queue), timeout)
 

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -23,6 +23,8 @@ class ReliableRedisBackend(object):
     (e.g. if we had 2 workers, both are processing a job, we kill the queues
     and lower the number of workers to 1, without doing this tidy up we would
     never process the job stuck in worker 2s processing queue.)
+
+    This backend has at-least-once semantics.
     """
 
     def __init__(self):

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -1,0 +1,114 @@
+from __future__ import absolute_import # For 'redis'
+
+import redis
+
+from ..job import Job
+from .. import app_settings
+
+class ReliableRedisBackend(object):
+    """
+    This backend manages a per-queue-per-worker 'processing' queue. E.g. if we
+    had a queue called 'django_lightweight_queue:things', and two workers, we
+    would have:
+      'django_lightweight_queue:things:processing:1'
+      'django_lightweight_queue:things:processing:2'
+
+    We enqueue tasks to the main queue via LPUSH, and workers grab jobs by
+    atomically popping jobs from the tail of the main queue into their
+    processing queue (via BRPOPLPUSH).
+
+    On startup we remove all jobs from any processing queues, and move to the
+    tail of the main queue, i.e. so they're processed next -- see `startup`
+    below.  This is to stop losing jobs if the number of workers is lowered
+    (e.g. if we had 2 workers, both are processing a job, we kill the queues
+    and lower the number of workers to 1, without doing this tidy up we would
+    never process the job stuck in worker 2s processing queue.)
+    """
+
+    def __init__(self):
+        self.client = redis.Redis(
+            host=app_settings.REDIS_HOST,
+            port=app_settings.REDIS_PORT,
+        )
+
+    def startup(self, queue):
+        main_queue_key = self._key(queue)
+
+        pattern = self._prefix_key(
+            'django_lightweight_queue:%s:processing:*' % queue,
+        )
+
+        processing_queue_keys = self.client.keys(pattern)
+
+        def move_processing_jobs_to_main(pipe):
+            # Collect all the data we need to add, before adding the data back
+            # to the main queue of and clearing the processing queues
+            # atomically, so if this crashes, we don't lose jobs
+            all_data = []
+            for key in processing_queue_keys:
+                all_data.extend(pipe.lrange(key, 0, -1))
+
+            pipe.multi()
+
+            # NB we RPUSH, which means these jobs will get processed next
+            pipe.rpush(main_queue_key, *all_data)
+            pipe.delete(*processing_queue_keys)
+
+        # Will run the above function, WATCH-ing the processing_queue_keys. If
+        # any of them change prior to transaction execution, it will abort and
+        # retry.
+        self.client.transaction(
+            move_processing_jobs_to_main,
+            processing_queue_keys,
+        )
+
+    def enqueue(self, job, queue):
+        self.client.lpush(self._key(queue), job.to_json())
+
+    def dequeue(self, queue, worker_number, timeout):
+        main_queue_key = self._key(queue)
+        processing_queue_key = self._processing_key(queue, worker_number)
+
+        # Pop any jobs off our 'processing' queue - but do not block doing so -
+        # this is to catch the fact there may be a job already in our
+        # processing queue if this worker crashed and has just been restarted.
+        # NB different purpose than 'startup' method above.
+        data = self.client.rpop(processing_queue_key)
+        if data:
+            return Job.from_json(data)
+
+        # Otherwise, block trying to move a job from the main queue into our
+        # processing queue, and process it.
+        data = self.client.brpoplpush(main_queue_key, processing_queue_key)
+        if data:
+            return Job.from_json(data)
+
+    def processed_job(self, queue, worker_number, job):
+        data = job.to_json()
+
+        self.client.lrem(self._processing_key(queue, worker_number), data)
+
+    def length(self, queue):
+        return self.client.llen(self._key(queue))
+
+    def _key(self, queue):
+        key = 'django_lightweight_queue:%s' % queue
+
+        return self._prefix_key(key)
+
+    def _processing_key(self, queue, worker_number):
+        key = 'django_lightweight_queue:%s:processing:%s' % (
+            queue,
+            worker_number,
+        )
+
+        return self._prefix_key(key)
+
+    def _prefix_key(self, key):
+        if app_settings.REDIS_PREFIX:
+            return '%s:%s' % (
+                app_settings.REDIS_PREFIX,
+                key,
+            )
+
+        return key

--- a/django_lightweight_queue/backends/synchronous.py
+++ b/django_lightweight_queue/backends/synchronous.py
@@ -1,6 +1,9 @@
 import time
 
 class SynchronousBackend(object):
+    """
+    This backend has at-most-once semantics.
+    """
     def startup(self, queue):
         pass
 

--- a/django_lightweight_queue/backends/synchronous.py
+++ b/django_lightweight_queue/backends/synchronous.py
@@ -4,7 +4,7 @@ class SynchronousBackend(object):
     def enqueue(self, job, queue):
         job.run()
 
-    def dequeue(self, queue, timeout):
+    def dequeue(self, queue, worker_num, timeout):
         # Cannot dequeue from the synchronous backend but we can emulate by
         # never returning anything
         time.sleep(timeout)

--- a/django_lightweight_queue/backends/synchronous.py
+++ b/django_lightweight_queue/backends/synchronous.py
@@ -13,3 +13,6 @@ class SynchronousBackend(object):
         # The length is the number of items waiting to be processed, which can
         # be defined as always 0 for the synchronous backend
         return 0
+
+    def processed_job(self, queue, worker_num, job):
+        pass

--- a/django_lightweight_queue/backends/synchronous.py
+++ b/django_lightweight_queue/backends/synchronous.py
@@ -1,6 +1,9 @@
 import time
 
 class SynchronousBackend(object):
+    def startup(self, queue):
+        pass
+
     def enqueue(self, job, queue):
         job.run()
 

--- a/django_lightweight_queue/cron_scheduler.py
+++ b/django_lightweight_queue/cron_scheduler.py
@@ -42,7 +42,7 @@ class CronScheduler(multiprocessing.Process):
 
         self.log.debug("Starting")
 
-        backend = get_backend()
+        backend = get_backend('cron_scheduler')
         self.log.info("Loaded backend %s", backend)
 
         while self.running.value:

--- a/django_lightweight_queue/management/commands/queue_configuration.py
+++ b/django_lightweight_queue/management/commands/queue_configuration.py
@@ -1,6 +1,7 @@
 from django.core.management.base import NoArgsCommand
 
 from ... import app_settings
+from ...utils import get_backend
 from ...cron_scheduler import get_config
 
 class Command(NoArgsCommand):
@@ -8,19 +9,20 @@ class Command(NoArgsCommand):
         print "django-lightweight-queue"
         print "========================"
         print
-        print "{0:<15} {1:>5}".format("Queue name", "Concurrency")
+        print "{0:<55} {1:<5} {2}".format("Queue name", "Concurrency", "Backend")
         print "-" * 27
 
         for k, v in app_settings.WORKERS.iteritems():
-            print " {0:<14} {1}".format(k, v)
+            print " {0:<54} {1:<5} {2}".format(
+                k,
+                v,
+                get_backend(k).__class__.__name__,
+            )
 
         print
         print "Middleware:"
         for x in app_settings.MIDDLEWARE:
             print " * %s" % x
-
-        print
-        print "Backend: %s" % app_settings.BACKEND
 
         print
         print "Cron configuration"

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -58,7 +58,7 @@ class Command(NoArgsCommand):
         log.info("Starting queue runner")
 
         # Ensure children will be able to import our backend
-        get_backend()
+        get_backend('dummy')
 
         get_middleware()
         log.info("Loaded middleware")

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -52,7 +52,7 @@ def runner(log, log_filename_fn, touch_filename_fn, machine_number, machine_coun
     # backend per queue to do so.
     for queue in app_settings.WORKERS.keys():
         if not only_queue or only_queue == queue:
-            backend = get_backend()
+            backend = get_backend(queue)
             backend.startup(queue)
 
     # Used to determine the parallelism split

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -6,7 +6,7 @@ import multiprocessing
 from Queue import Empty
 
 from . import app_settings
-from .utils import set_process_title
+from .utils import set_process_title, get_backend
 from .worker import Worker
 from .cron_scheduler import CronScheduler, get_config
 
@@ -47,6 +47,13 @@ def runner(log, log_filename_fn, touch_filename_fn, machine_number, machine_coun
             cron_scheduler.start()
 
     workers = {}
+
+    # Some backends may require on-startup logic per-queue, initialise a dummy
+    # backend per queue to do so.
+    for queue in app_settings.WORKERS.keys():
+        if not only_queue or only_queue == queue:
+            backend = get_backend()
+            backend.startup(queue)
 
     # Used to determine the parallelism split
     job_number = 1

--- a/django_lightweight_queue/task.py
+++ b/django_lightweight_queue/task.py
@@ -91,4 +91,4 @@ class TaskWrapper(object):
         job = Job(self.path, args, kwargs, timeout, sigkill_on_stop)
         job.validate()
 
-        get_backend().enqueue(job, queue)
+        get_backend(queue).enqueue(job, queue)

--- a/django_lightweight_queue/utils.py
+++ b/django_lightweight_queue/utils.py
@@ -43,8 +43,11 @@ def get_path(path):
     return getattr(module, attr)
 
 @lru_cache()
-def get_backend():
-    return get_path(app_settings.BACKEND)()
+def get_backend(queue):
+    return get_path(app_settings.BACKEND_OVERRIDES.get(
+        queue,
+        app_settings.DEFAULT_BACKEND,
+    ))()
 
 @lru_cache()
 def get_middleware():

--- a/django_lightweight_queue/utils.py
+++ b/django_lightweight_queue/utils.py
@@ -46,7 +46,7 @@ def get_path(path):
 def get_backend(queue):
     return get_path(app_settings.BACKEND_OVERRIDES.get(
         queue,
-        app_settings.DEFAULT_BACKEND,
+        app_settings.BACKEND,
     ))()
 
 @lru_cache()

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -111,6 +111,8 @@ class Worker(multiprocessing.Process):
             with open(self.touch_filename, 'a'):
                 os.utime(self.touch_filename, None)
 
+        backend.processed_job(self.queue, self.worker_num, job)
+
         # Emulate Django's request_finished signal and close all of our
         # connections. Django assumes that making a DB connection is cheap, so
         # it's probably safe to assume that too.

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -54,7 +54,7 @@ class Worker(multiprocessing.Process):
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
         # Each worker gets it own backend
-        backend = get_backend()
+        backend = get_backend(self.queue)
         self.log.info("Loaded backend %s", backend)
 
         time_item_last_processed = datetime.datetime.utcnow()

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -94,7 +94,7 @@ class Worker(multiprocessing.Process):
         # Tell master process that we are not processing anything.
         self.tell_master(None, False)
 
-        job = backend.dequeue(self.queue, 15)
+        job = backend.dequeue(self.queue, self.worker_num, 15)
         if job is None:
             return False
 


### PR DESCRIPTION
#### Changes
Adds a new queue backend which guarantees (famous last words..) that each job will be run at least once, as opposed to at most once under the `redis` backend. The docstring for ReliableRedisBackend describes how the backend operates, copied here:
```
    This backend manages a per-queue-per-worker 'processing' queue. E.g. if we
    had a queue called 'django_lightweight_queue:things', and two workers, we
    would have:
      'django_lightweight_queue:things:processing:1'
      'django_lightweight_queue:things:processing:2'

    We enqueue tasks to the main queue via LPUSH, and workers grab jobs by
    atomically popping jobs from the tail of the main queue into their
    processing queue (via BRPOPLPUSH).

    On startup we remove all jobs from any processing queues, and move to the
    tail of the main queue, i.e. so they're processed next -- see `startup`
    below.  This is to stop losing jobs if the number of workers is lowered
    (e.g. if we had 2 workers, both are processing a job, we kill the queues
    and lower the number of workers to 1, without doing this tidy up we would
    never process the job stuck in worker 2s processing queue.)
```

Also worth noting is the attempt at `RPOP` in `deque`, also documented.

### Reviewed
 - [x] @prophile
 - [ ] @tavva
 - [x] @danpalmer