### PR TITLE
Add support for non-transactional tasks

### DIFF
--- a/django_lightweight_queue/job.py
+++ b/django_lightweight_queue/job.py
@@ -12,12 +12,14 @@ class Job(object):
         kwargs,
         timeout=None,
         sigkill_on_stop=False,
+        middleware_options=None,
     ):
         self.path = path
         self.args = args
         self.kwargs = kwargs
         self.timeout = timeout
         self.sigkill_on_stop = sigkill_on_stop
+        self.middleware_options = middleware_options or {}
 
         self._json = None
 
@@ -32,6 +34,27 @@ class Job(object):
         job._json = val
 
         return job
+
+    def get_middleware_option(dotted_name, default=None):
+        """
+        Fetch an option on this job for middleware.
+
+        Option names are generally expected to start with the name of the
+        middleware they relate to, but it is up to the middleware in question
+        to handle this.
+
+        The name of the option should be dot separated, the dots will be used to
+        separate the name of the middleware from the name of the option. At each
+        level the name is used as a key into the options dict, starting with the
+        middleware_options which was passed to the `task` decorator.
+        """
+
+        parts = dotted_name.split('.')
+        options = self.middleware_options
+        for part in parts[:-1]:
+            options = options.get(part, {})
+
+        return options.get(parts[-1], default)
 
     def run(self):
         start = time.time()

--- a/django_lightweight_queue/job.py
+++ b/django_lightweight_queue/job.py
@@ -5,7 +5,14 @@ import time
 from .utils import get_path, get_middleware
 
 class Job(object):
-    def __init__(self, path, args, kwargs, timeout=None, sigkill_on_stop=False):
+    def __init__(
+        self,
+        path,
+        args,
+        kwargs,
+        timeout=None,
+        sigkill_on_stop=False,
+    ):
         self.path = path
         self.args = args
         self.kwargs = kwargs

--- a/django_lightweight_queue/middleware/transaction.py
+++ b/django_lightweight_queue/middleware/transaction.py
@@ -3,13 +3,14 @@ from django.db import transaction, connection
 from ..task import task
 
 class TransactionMiddleware(object):
-    _transaction_started = False
+    def __init__(self):
+        self._transaction_started = False
 
-    def _enable_transaction(job):
+    def _enable_transaction(self, job):
         return job.get_middleware_option('transaction.enabled', True)
 
     def process_job(self, job):
-        if _enable_transaction(job):
+        if self._enable_transaction(job):
             transaction.atomic().__enter__()
             self._transaction_started = True
 

--- a/django_lightweight_queue/middleware/transaction.py
+++ b/django_lightweight_queue/middleware/transaction.py
@@ -22,10 +22,6 @@ class TransactionMiddleware(object):
         if self._transaction_started:
             transaction.atomic().__exit__(*exc_info)
 
-def non_transactional_task(*args, **kwargs):
-    kwargs.setdefault('transaction', {}).setdefault('enabled', False)
-    return task(*args, **kwargs)
-
 # Legacy
 if not hasattr(connection, 'in_atomic_block'):
     class TransactionMiddleware(object):

--- a/django_lightweight_queue/task.py
+++ b/django_lightweight_queue/task.py
@@ -4,7 +4,12 @@ from .utils import get_backend
 from . import app_settings
 
 class task(object):
-    def __init__(self, queue='default', timeout=None, sigkill_on_stop=False):
+    def __init__(
+        self,
+        queue='default',
+        timeout=None,
+        sigkill_on_stop=False,
+    ):
         """
         Define a task to be run.
 
@@ -63,10 +68,15 @@ class task(object):
         app_settings.WORKERS.setdefault(self.queue, 1)
 
     def __call__(self, fn):
-        return TaskWrapper(fn, self.queue, self.timeout, self.sigkill_on_stop)
+        return TaskWrapper(
+            fn,
+            self.queue,
+            self.timeout,
+            self.sigkill_on_stop,
+        )
 
 class TaskWrapper(object):
-    def __init__(self, fn, queue, timeout, sigkill_on_stop):
+    def __init__(self, fn, queue, timeout, sigkill_on_stop, middleware_options):
         self.fn = fn
         self.queue = queue
         self.timeout = timeout
@@ -88,7 +98,13 @@ class TaskWrapper(object):
         # Allow queue overrides, but you must ensure that this queue will exist
         queue = kwargs.pop('django_lightweight_queue_queue', self.queue)
 
-        job = Job(self.path, args, kwargs, timeout, sigkill_on_stop)
+        job = Job(
+            self.path,
+            args,
+            kwargs,
+            timeout,
+            sigkill_on_stop,
+        )
         job.validate()
 
         get_backend(queue).enqueue(job, queue)

--- a/django_lightweight_queue/task.py
+++ b/django_lightweight_queue/task.py
@@ -9,6 +9,7 @@ class task(object):
         queue='default',
         timeout=None,
         sigkill_on_stop=False,
+        middleware_options=None,
     ):
         """
         Define a task to be run.
@@ -40,6 +41,12 @@ class task(object):
             processor is shut down. The default behaviour is to let it run to
             completion.
 
+            `middleware_options` -- A `dict` of options for the middleware which
+            may be being used. Keys and values are determined entirely by the
+            middleware in question, though it is expected that top level keys
+            will correspond to the last name segment of a middleware and top
+            level values will be `dict`s of options for that middleware.
+
         For example::
 
             @task(sigkill_on_stop=True, timeout=60)
@@ -64,6 +71,7 @@ class task(object):
         self.queue = queue
         self.timeout = timeout
         self.sigkill_on_stop = sigkill_on_stop
+        self.middleware_options = middleware_options or {}
 
         app_settings.WORKERS.setdefault(self.queue, 1)
 
@@ -73,6 +81,7 @@ class task(object):
             self.queue,
             self.timeout,
             self.sigkill_on_stop,
+            self.middleware_options,
         )
 
 class TaskWrapper(object):
@@ -81,6 +90,7 @@ class TaskWrapper(object):
         self.queue = queue
         self.timeout = timeout
         self.sigkill_on_stop = sigkill_on_stop
+        self.middleware_options = middleware_options
 
         self.path = '%s.%s' % (fn.__module__, fn.__name__)
 
@@ -104,6 +114,7 @@ class TaskWrapper(object):
             kwargs,
             timeout,
             sigkill_on_stop,
+            middleware_options,
         )
         job.validate()
 


### PR DESCRIPTION
Introduce a mechanism for passing options to middlewares and use this in the transactional middleware to allow some tasks to opt out of being wrapped in a transaction.
