### PR TITLE
Support specifying the number of workers when specifying a queue to run

### DIFF
--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -41,14 +41,14 @@ class Command(NoArgsCommand):
             )
 
         try:
-            only_queue_workers = int(options['num_queue_workers'])
+            num_only_queue_workers = int(options['num_queue_workers'])
         except TypeError:
-            only_queue_workers = None
+            num_only_queue_workers = None
         else:
-            if only_queue_workers == 0:
+            if num_only_queue_workers == 0:
                 raise CommandError("Nothing to do! (queue-workers is zero)")
 
-            if only_queue_workers < 0:
+            if num_only_queue_workers < 0:
                 raise CommandError("Cannot have negative queue-workers")
 
         level = {
@@ -99,7 +99,7 @@ class Command(NoArgsCommand):
                 machine_number=int(options['machine_number']),
                 machine_count=int(options['machine_count']),
                 only_queue=options['only_queue'],
-                only_queue_workers=only_queue_workers,
+                num_only_queue_workers=num_only_queue_workers,
             )
 
         # fork() only after we have started enough to catch failure, including

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -3,7 +3,7 @@ import optparse
 import daemonize
 
 from django.apps import apps
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import CommandError, NoArgsCommand
 
 from ...utils import get_backend, get_middleware, configure_logging
 from ...runner import runner
@@ -35,7 +35,7 @@ class Command(NoArgsCommand):
             options['num_queue_workers'] is not None and
             options['only_queue'] is None
         ):
-            raise ValueError(
+            raise CommandError(
                 "A value for 'queue-workers' without a value for 'only-queue' "
                 "has no meaning.",
             )
@@ -46,10 +46,10 @@ class Command(NoArgsCommand):
             only_queue_workers = None
         else:
             if only_queue_workers == 0:
-                raise ValueError("Nothing to do! (queue-workers is zero)")
+                raise CommandError("Nothing to do! (queue-workers is zero)")
 
             if only_queue_workers < 0:
-                raise ValueError("Cannot have negative queue-workers")
+                raise CommandError("Cannot have negative queue-workers")
 
         level = {
             0: logging.WARNING,

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -10,15 +10,7 @@ from .utils import set_process_title, get_backend
 from .worker import Worker
 from .cron_scheduler import CronScheduler, get_config
 
-def runner(
-    log,
-    log_filename_fn,
-    touch_filename_fn,
-    machine_number,
-    machine_count,
-    only_queue=None,
-    num_only_queue_workers=None,
-):
+def runner(log, log_filename_fn, touch_filename_fn, machine_number, machine_count, only_queue=None, num_only_queue_workers=None):
     # Set a dummy title now; multiprocessing will create an extra process
     # which will inherit it - we'll set the real title afterwards
     set_process_title("Internal master process")

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -17,7 +17,7 @@ def runner(
     machine_number,
     machine_count,
     only_queue=None,
-    only_queue_workers=None,
+    num_only_queue_workers=None,
 ):
     # Set a dummy title now; multiprocessing will create an extra process
     # which will inherit it - we'll set the real title afterwards
@@ -70,8 +70,8 @@ def runner(
         if only_queue and only_queue != queue:
             continue
 
-        if only_queue and only_queue_workers is not None:
-            num_workers = only_queue_workers
+        if only_queue and num_only_queue_workers is not None:
+            num_workers = num_only_queue_workers
 
         for x in range(1, num_workers + 1):
             # We don't go out of our way to start workers on startup - we let

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -11,14 +11,14 @@ from .worker import Worker
 from .cron_scheduler import CronScheduler, get_config
 
 def runner(
-        log,
-        log_filename_fn,
-        touch_filename_fn,
-        machine_number,
-        machine_count,
-        only_queue=None,
-        only_queue_workers=None,
-    ):
+    log,
+    log_filename_fn,
+    touch_filename_fn,
+    machine_number,
+    machine_count,
+    only_queue=None,
+    only_queue_workers=None,
+):
     # Set a dummy title now; multiprocessing will create an extra process
     # which will inherit it - we'll set the real title afterwards
     set_process_title("Internal master process")

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -17,6 +17,7 @@ def runner(
         machine_number,
         machine_count,
         only_queue=None,
+        only_queue_workers=None,
     ):
     # Set a dummy title now; multiprocessing will create an extra process
     # which will inherit it - we'll set the real title afterwards
@@ -68,6 +69,9 @@ def runner(
     for queue, num_workers in sorted(app_settings.WORKERS.iteritems()):
         if only_queue and only_queue != queue:
             continue
+
+        if only_queue and only_queue_workers is not None:
+            num_workers = only_queue_workers
 
         for x in range(1, num_workers + 1):
             # We don't go out of our way to start workers on startup - we let

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -10,7 +10,14 @@ from .utils import set_process_title, get_backend
 from .worker import Worker
 from .cron_scheduler import CronScheduler, get_config
 
-def runner(log, log_filename_fn, touch_filename_fn, machine_number, machine_count, only_queue=None):
+def runner(
+        log,
+        log_filename_fn,
+        touch_filename_fn,
+        machine_number,
+        machine_count,
+        only_queue=None,
+    ):
     # Set a dummy title now; multiprocessing will create an extra process
     # which will inherit it - we'll set the real title afterwards
     set_process_title("Internal master process")


### PR DESCRIPTION
This avoids needing to modify the global configuration when running additional workers.