### PR TITLE
Rearrange command line options

### DIFF
--- a/django_lightweight_queue/management/commands/queue_configuration.py
+++ b/django_lightweight_queue/management/commands/queue_configuration.py
@@ -1,12 +1,12 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from ... import app_settings
 from ...utils import get_backend
 from ...cron_scheduler import get_config
 
 
-class Command(NoArgsCommand):
-    def handle_noargs(self, **options):
+class Command(BaseCommand):
+    def handle(self, **options):
         print "django-lightweight-queue"
         print "========================"
         print

--- a/django_lightweight_queue/management/commands/queue_configuration.py
+++ b/django_lightweight_queue/management/commands/queue_configuration.py
@@ -4,6 +4,7 @@ from ... import app_settings
 from ...utils import get_backend
 from ...cron_scheduler import get_config
 
+
 class Command(NoArgsCommand):
     def handle_noargs(self, **options):
         print "django-lightweight-queue"

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -88,10 +88,7 @@ class Command(NoArgsCommand):
         log.info("Loaded middleware")
 
         # Configuration overrides
-        try:
-            app_settings.WORKERS[only_queue] = num_only_queue_workers
-        except KeyError:
-            pass
+        app_settings.WORKERS[only_queue] = num_only_queue_workers
 
         # Ensure children will be able to import most things, but also try and
         # save memory by importing as much as possible before the fork() as it

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -88,7 +88,8 @@ class Command(NoArgsCommand):
         log.info("Loaded middleware")
 
         # Configuration overrides
-        app_settings.WORKERS[only_queue] = num_only_queue_workers
+        if num_only_queue_workers is not None:
+            app_settings.WORKERS[only_queue] = num_only_queue_workers
 
         # Ensure children will be able to import most things, but also try and
         # save memory by importing as much as possible before the fork() as it

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -5,6 +5,7 @@ import daemonize
 from django.apps import apps
 from django.core.management.base import CommandError, NoArgsCommand
 
+from ... import app_settings
 from ...utils import get_backend, get_middleware, configure_logging
 from ...runner import runner
 
@@ -85,6 +86,11 @@ class Command(NoArgsCommand):
         get_middleware()
         log.info("Loaded middleware")
 
+        try:
+            app_settings.WORKERS[only_queue] = num_only_queue_workers
+        except KeyError:
+            pass
+
         # Ensure children will be able to import most things, but also try and
         # save memory by importing as much as possible before the fork() as it
         # has copy-on-write semantics.
@@ -99,7 +105,6 @@ class Command(NoArgsCommand):
                 machine_number=int(options['machine_number']),
                 machine_count=int(options['machine_count']),
                 only_queue=options['only_queue'],
-                num_only_queue_workers=num_only_queue_workers,
             )
 
         # fork() only after we have started enough to catch failure, including

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         only_queue = options['only_queue']
         if (
             options['num_queue_workers'] is not None and
-            only_queue
+            only_queue is None
         ):
             raise CommandError(
                 "A value for 'queue-workers' without a value for 'only-queue' "

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -32,9 +32,10 @@ class Command(NoArgsCommand):
         # ensure an int.
         verbosity = int(options['verbosity'])
 
+        only_queue = options['only_queue']
         if (
             options['num_queue_workers'] is not None and
-            options['only_queue'] is None
+            only_queue
         ):
             raise CommandError(
                 "A value for 'queue-workers' without a value for 'only-queue' "
@@ -104,7 +105,7 @@ class Command(NoArgsCommand):
                 touch_filename,
                 machine_number=int(options['machine_number']),
                 machine_count=int(options['machine_count']),
-                only_queue=options['only_queue'],
+                only_queue=only_queue,
             )
 
         # fork() only after we have started enough to catch failure, including

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -9,6 +9,7 @@ from ... import app_settings
 from ...utils import get_backend, get_middleware, configure_logging
 from ...runner import runner
 
+
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
         optparse.make_option('--pidfile', action='store', dest='pidfile', default=None,

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -87,6 +87,7 @@ class Command(NoArgsCommand):
         get_middleware()
         log.info("Loaded middleware")
 
+        # Configuration overrides
         try:
             app_settings.WORKERS[only_queue] = num_only_queue_workers
         except KeyError:

--- a/django_lightweight_queue/management/commands/queue_runner.py
+++ b/django_lightweight_queue/management/commands/queue_runner.py
@@ -1,34 +1,32 @@
 import logging
-import optparse
 import daemonize
 
 from django.apps import apps
-from django.core.management.base import CommandError, NoArgsCommand
+from django.core.management.base import CommandError, BaseCommand
 
 from ... import app_settings
 from ...utils import get_backend, get_middleware, configure_logging
 from ...runner import runner
 
 
-class Command(NoArgsCommand):
-    option_list = NoArgsCommand.option_list + (
-        optparse.make_option('--pidfile', action='store', dest='pidfile', default=None,
-            help="Fork and write pidfile to this file."),
-        optparse.make_option('--logfile', action='store', dest='logfile', default=None,
-            help="Log to the specified file."),
-        optparse.make_option('--touchfile', action='store', dest='touchfile', default=None,
-            help="touch(1) the specified file after running a job."),
-        optparse.make_option('--machine', action='store', dest='machine_number', default='1',
-            help="Machine number, for parallelism"),
-        optparse.make_option('--of', action='store', dest='machine_count', default='1',
-            help="Total number of machines running the queues"),
-        optparse.make_option('--only-queue', action='store', default=None,
-            help="Only run the given queue, useful for local debugging"),
-        optparse.make_option('--num-queue-workers', action='store', default=None,
-            help="The number of queue workers to run, only valid when running a specific queue"),
-    )
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('--pidfile', action='store', dest='pidfile', default=None,
+            help="Fork and write pidfile to this file.")
+        parser.add_argument('--logfile', action='store', dest='logfile', default=None,
+            help="Log to the specified file.")
+        parser.add_argument('--touchfile', action='store', dest='touchfile', default=None,
+            help="touch(1) the specified file after running a job.")
+        parser.add_argument('--machine', action='store', dest='machine_number', default='1',
+            help="Machine number, for parallelism")
+        parser.add_argument('--of', action='store', dest='machine_count', default='1',
+            help="Total number of machines running the queues")
+        parser.add_argument('--only-queue', action='store', default=None,
+            help="Only run the given queue, useful for local debugging")
+        parser.add_argument('--num-queue-workers', action='store', default=None,
+            help="The number of queue workers to run, only valid when running a specific queue")
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         # Django < 1.8.3 leaves options['verbosity'] as a string so we cast to
         # ensure an int.
         verbosity = int(options['verbosity'])

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -10,7 +10,7 @@ from .utils import set_process_title, get_backend
 from .worker import Worker
 from .cron_scheduler import CronScheduler, get_config
 
-def runner(log, log_filename_fn, touch_filename_fn, machine_number, machine_count, only_queue=None, num_only_queue_workers=None):
+def runner(log, log_filename_fn, touch_filename_fn, machine_number, machine_count, only_queue=None):
     # Set a dummy title now; multiprocessing will create an extra process
     # which will inherit it - we'll set the real title afterwards
     set_process_title("Internal master process")
@@ -61,9 +61,6 @@ def runner(log, log_filename_fn, touch_filename_fn, machine_number, machine_coun
     for queue, num_workers in sorted(app_settings.WORKERS.iteritems()):
         if only_queue and only_queue != queue:
             continue
-
-        if only_queue and num_only_queue_workers is not None:
-            num_workers = num_only_queue_workers
 
         for x in range(1, num_workers + 1):
             # We don't go out of our way to start workers on startup - we let


### PR DESCRIPTION
Tidy up the existing command line options to have slightly cleaner implementations and move to using `BaseCommand` and `argparse` rather than `NoArgsCommand` and `optparse`.