### PR TITLE
Add a mechanism to deduplicate queues

### DIFF
--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -108,8 +108,7 @@ class ReliableRedisBackend(object):
 
         We use ``Job.identity_without_created`` to collect up jobs which would
         be identical when run but potentially different by timestamp. We then
-        remove all but the first (oldest) of those jobs, relying on the
-        assumption that the created timestamp of the oldest job is unique.
+        remove all but the first (oldest) of those jobs one at a time.
 
         Returns a tuple of (original_size, new_size) of the queue.
         """

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -122,7 +122,7 @@ class ReliableRedisBackend(object):
             return 0, 0
 
         # A mapping of job_identity -> list of raw_job data; the entries in the
-        # latter lists are assumed to be unique due to their created timestamps
+        # latter list are ordered from newest to oldest
         jobs = {}
 
         for raw_data in self.client.lrange(main_queue_key, 0, -1):

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -119,9 +119,9 @@ class ReliableRedisBackend(object):
         jobs = {}
 
         for raw_data in self.client.lrange(main_queue_key, 0, -1):
-            job_id = Job.from_json(raw_data).identity_without_created()
+            job_identity = Job.from_json(raw_data).identity_without_created()
 
-            jobs.setdefault(job_id, []).append(raw_data)
+            jobs.setdefault(job_identity, []).append(raw_data)
 
         for raw_jobs in jobs.values():
             # Leave the first one in the queue

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -102,6 +102,13 @@ class ReliableRedisBackend(object):
         return self.client.llen(self._key(queue))
 
     def deduplicate(self, queue):
+        """
+        Deduplicate the given queue by comparing the jobs in a manner which
+        ignores their created timestamps.
+
+        Returns a tuple of (original_size, new_size) of the queue.
+        """
+
         main_queue_key = self._key(queue)
 
         original_size = self.client.llen(main_queue_key)

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -131,10 +131,11 @@ class ReliableRedisBackend(object):
             jobs.setdefault(job_identity, []).append(raw_data)
 
         for raw_jobs in jobs.values():
-            # Leave the oldest in the queue (relying on the assumption that its
-            # timestamp is unique)
-            for raw_data in raw_jobs[1:]:
-                self.client.lrem(raw_data)
+            # Leave the oldest in the queue
+            for raw_data in raw_jobs[:-1]:
+                # Remove only one instance of this data (thus coping with
+                # unlikely but possible non-unique entries)
+                self.client.lrem(main_queue_key, raw_data, 1)
 
         return original_size, self.client.llen(main_queue_key)
 

--- a/django_lightweight_queue/job.py
+++ b/django_lightweight_queue/job.py
@@ -108,4 +108,6 @@ class Job(object):
 
     def identity_without_created(self):
         """Returns an object which can be used to identify equivalent jobs"""
-        return json.dumps(self.as_dict(), sort_keys=True)
+        self_dict = self.as_dict()
+        del self_dict['created_time']
+        return json.dumps(self_dict, sort_keys=True)

--- a/django_lightweight_queue/job.py
+++ b/django_lightweight_queue/job.py
@@ -105,3 +105,7 @@ class Job(object):
         if self._json is None:
             self._json = json.dumps(self.as_dict())
         return self._json
+
+    def identity_without_created(self):
+        """Returns an object which can be used to identify equivalent jobs"""
+        return json.dumps(self.as_dict(), sort_keys=True)

--- a/django_lightweight_queue/management/commands/queue_deduplicate.py
+++ b/django_lightweight_queue/management/commands/queue_deduplicate.py
@@ -7,7 +7,11 @@ class Command(BaseCommand):
     help = "Command to deduplicate tasks in a redis-backed queue"
 
     def add_arguments(self, parser):
-        parser.add_argument('queue', action='store', help="The queue to deduplicate")
+        parser.add_argument(
+            'queue',
+            action='store',
+            help="The queue to deduplicate",
+        )
 
     def handle(self, queue, **options):
         backend = get_backend(queue)

--- a/django_lightweight_queue/management/commands/queue_deduplicate.py
+++ b/django_lightweight_queue/management/commands/queue_deduplicate.py
@@ -26,9 +26,16 @@ class Command(BaseCommand):
 
         original_size, new_size = backend.deduplicate(queue)
 
-        self.stdout.write(
-            "Deduplication reduced the queue from %d jobs to %d job(s)" % (
-                original_size,
-                new_size,
-            ),
-        )
+        if original_size == new_size:
+            self.stdout.write(
+                "No duplicate jobs detected (queue length remains %d)" % (
+                    original_size,
+                ),
+            )
+        else:
+            self.stdout.write(
+                "Deduplication reduced the queue from %d jobs to %d job(s)" % (
+                    original_size,
+                    new_size,
+                ),
+            )

--- a/django_lightweight_queue/management/commands/queue_deduplicate.py
+++ b/django_lightweight_queue/management/commands/queue_deduplicate.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         original_size, new_size = backend.deduplicate(queue)
 
         self.stdout.write(
-            "Deduplication reduced the queue from %d jobs to %d jobs" % (
+            "Deduplication reduced the queue from %d jobs to %d job(s)" % (
                 original_size,
                 new_size,
             ),

--- a/django_lightweight_queue/management/commands/queue_deduplicate.py
+++ b/django_lightweight_queue/management/commands/queue_deduplicate.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from ...utils import get_backend
+
+
+class Command(BaseCommand):
+    help = "Command to deduplicate tasks in a redis-backed queue"
+
+    def add_arguments(self, parser):
+        parser.add_argument('queue', action='store', help="The queue to deduplicate")
+
+    def handle(self, queue, **options):
+        backend = get_backend(queue)
+
+        if not hasattr(backend, 'deduplicate'):
+            raise CommandError(
+                "Configured backend '%s.%s' doesn't support deduplication" % (
+                    type(backend).__module__,
+                    type(backend).__name__,
+                ),
+            )
+
+        original_size, new_size = backend.deduplicate(queue)
+
+        self.stdout.write(
+            "Deduplication reduced the queue from %d jobs to %d jobs" % (
+                original_size,
+                new_size,
+            ),
+        )

--- a/runtests
+++ b/runtests
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import django
+
+from django.conf import settings
+from django.test.utils import get_runner
+
+if __name__ == '__main__':
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
+    django.setup()
+    failures = get_runner(settings)().run_tests(sys.argv[1:])
+    sys.exit(bool(failures))

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -1,0 +1,18 @@
+class RedisCleanupMixin(object):
+    client = None
+    prefix = None
+
+    def setUp(self):
+        super(RedisCleanupMixin, self).setUp()
+        self.assertIsNotNone(self.client, "Need a redis client to be provided")
+
+    def tearDown(self):
+        root = '*'
+        if self.prefix is not None:
+            root = '%s*' % (self.prefix,)
+
+        keys = self.client.keys(root)
+        for key in keys:
+            self.client.delete(key)
+
+        super(RedisCleanupMixin, self).tearDown()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,1 @@
+SECRET_KEY = 'very-secret-value'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,1 +1,3 @@
 SECRET_KEY = 'very-secret-value'
+
+LIGHTWEIGHT_QUEUE_REDIS_PREFIX = 'tests:'

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,0 +1,66 @@
+import datetime
+import unittest
+
+from django_lightweight_queue.job import Job
+
+
+class JobTests(unittest.TestCase):
+    longMessage = True
+
+    def create_job(self, path='path', args=('args',), kwargs=None, timeout=None, sigkill_on_stop=False, created_time=None):
+        if created_time is None:
+            created_time = self.start_time
+
+        job = Job(path, args, kwargs, timeout, sigkill_on_stop)
+        job.created_time = created_time
+
+        return job
+
+    def setUp(self):
+        super(JobTests, self).setUp()
+        self.start_time = datetime.datetime.utcnow()
+
+    def test_identity_same_created_time(self):
+        job1 = self.create_job(
+            created_time=datetime.datetime(2018, 1, 1),
+        )
+
+        job2 = self.create_job(
+            created_time=datetime.datetime(2018, 1, 1),
+        )
+
+        self.assertEqual(
+            job1.identity_without_created(),
+            job2.identity_without_created(),
+            "Identities should match",
+        )
+
+    def test_identity_different_created_time(self):
+        job1 = self.create_job(
+            created_time=datetime.datetime(2018, 1, 1),
+        )
+
+        job2 = self.create_job(
+            created_time=datetime.datetime(2018, 2, 2),
+        )
+
+        self.assertEqual(
+            job1.identity_without_created(),
+            job2.identity_without_created(),
+            "Identities should match",
+        )
+
+    def test_identity_different_args(self):
+        job1 = self.create_job(
+            args=('args1',),
+        )
+
+        job2 = self.create_job(
+            args=('args2',),
+        )
+
+        self.assertNotEqual(
+            job1.identity_without_created(),
+            job2.identity_without_created(),
+            "Identities should match",
+        )

--- a/tests/test_reliable_redis_backend.py
+++ b/tests/test_reliable_redis_backend.py
@@ -1,0 +1,238 @@
+import datetime
+import unittest
+
+from django_lightweight_queue.job import Job
+from django_lightweight_queue.backends.reliable_redis import ReliableRedisBackend
+
+from . import settings
+from .mixins import RedisCleanupMixin
+
+
+class ReliableRedisDeduplicationTests(RedisCleanupMixin, unittest.TestCase):
+    longMessage = True
+    prefix = settings.LIGHTWEIGHT_QUEUE_REDIS_PREFIX
+
+    def create_job(self, path='path', args=('args',), kwargs=None, timeout=None, sigkill_on_stop=False, created_time=None):
+        if created_time is None:
+            created_time = self.start_time
+
+        job = Job(path, args, kwargs, timeout, sigkill_on_stop)
+        job.created_time = created_time
+
+        return job
+
+    def enqueue_job(self, queue, *args, **kwargs):
+        job = self.create_job(*args, **kwargs)
+        self.backend.enqueue(job, queue)
+        return job
+
+    def setUp(self):
+        self.backend = ReliableRedisBackend()
+        self.client = self.backend.client
+
+        super(ReliableRedisDeduplicationTests, self).setUp()
+
+        self.start_time = datetime.datetime.utcnow()
+
+    def test_empty_queue(self):
+        result = self.backend.deduplicate('empty-queue')
+        self.assertEqual(
+            (0, 0),
+            result,
+            "Should do nothing when queue empty",
+        )
+
+    def test_single_entry_in_queue(self):
+        QUEUE = 'single-job-queue'
+
+        self.enqueue_job(QUEUE)
+
+        # sanity check
+        self.assertEqual(
+            1,
+            self.backend.length(QUEUE),
+        )
+
+        result = self.backend.deduplicate(QUEUE)
+        self.assertEqual(
+            (1, 1),
+            result,
+            "Should do nothing when queue has only unique jobs",
+        )
+
+        self.assertEqual(
+            1,
+            self.backend.length(QUEUE),
+            "Should still be a single entry in the queue"
+        )
+
+    def test_unique_entries_in_queue(self):
+        QUEUE = 'unique-jobs-queue'
+
+        self.enqueue_job(QUEUE, args=('args1',))
+        self.enqueue_job(QUEUE, args=('args2',))
+
+        # sanity check
+        self.assertEqual(
+            2,
+            self.backend.length(QUEUE),
+        )
+
+        result = self.backend.deduplicate(QUEUE)
+        self.assertEqual(
+            (2, 2),
+            result,
+            "Should do nothing when queue has only unique jobs",
+        )
+
+        self.assertEqual(
+            2,
+            self.backend.length(QUEUE),
+            "Should still be a single entry in the queue"
+        )
+
+    def test_duplicate_entries_in_queue(self):
+        QUEUE = 'duplicate-jobs-queue'
+
+        self.enqueue_job(QUEUE)
+        self.enqueue_job(QUEUE)
+
+        # sanity check
+        self.assertEqual(
+            2,
+            self.backend.length(QUEUE),
+        )
+
+        result = self.backend.deduplicate(QUEUE)
+        self.assertEqual(
+            (2, 1),
+            result,
+            "Should remove duplicate entries from queue",
+        )
+
+        self.assertEqual(
+            1,
+            self.backend.length(QUEUE),
+            "Should still be a single entry in the queue"
+        )
+
+    def test_preserves_order_with_fixed_timestamps(self):
+        QUEUE = 'job-queue'
+        WORKER_NUMBER = 0
+
+        self.enqueue_job(QUEUE, args=['args1'])
+        self.enqueue_job(QUEUE, args=['args2'])
+        self.enqueue_job(QUEUE, args=['args1'])
+        self.enqueue_job(QUEUE, args=['args3'])
+        self.enqueue_job(QUEUE, args=['args2'])
+        self.enqueue_job(QUEUE, args=['args1'])
+
+        # sanity check
+        self.assertEqual(
+            6,
+            self.backend.length(QUEUE),
+        )
+
+        result = self.backend.deduplicate(QUEUE)
+        self.assertEqual(
+            (6, 3),
+            result,
+            "Should remove duplicate entries from queue",
+        )
+
+        self.assertEqual(
+            3,
+            self.backend.length(QUEUE),
+            "Wrong number of jobs remaining in queue"
+        )
+
+        job = self.backend.dequeue(QUEUE, WORKER_NUMBER, timeout=1)
+        self.assertEqual(
+            ['args1'],
+            job.args,
+            "First job dequeued should be the first job enqueued",
+        )
+
+        self.backend.processed_job(QUEUE, WORKER_NUMBER, job)
+
+        job = self.backend.dequeue(QUEUE, WORKER_NUMBER, timeout=1)
+        self.assertEqual(
+            ['args2'],
+            job.args,
+            "Second job dequeued should be the second job enqueued",
+        )
+
+        self.backend.processed_job(QUEUE, WORKER_NUMBER, job)
+
+        job = self.backend.dequeue(QUEUE, WORKER_NUMBER, timeout=1)
+        self.assertEqual(
+            ['args3'],
+            job.args,
+            "Third job dequeued should be the third job enqueued",
+        )
+
+    def test_preserves_order_with_unique_timestamps(self):
+        QUEUE = 'job-queue'
+        WORKER_NUMBER = 0
+
+        time = self.start_time
+        self.enqueue_job(QUEUE, args=['args1'], created_time=time)
+
+        time += datetime.timedelta(seconds=1)
+        self.enqueue_job(QUEUE, args=['args2'], created_time=time)
+
+        time += datetime.timedelta(seconds=1)
+        self.enqueue_job(QUEUE, args=['args1'], created_time=time)
+
+        time += datetime.timedelta(seconds=1)
+        self.enqueue_job(QUEUE, args=['args3'], created_time=time)
+
+        time += datetime.timedelta(seconds=1)
+        self.enqueue_job(QUEUE, args=['args2'], created_time=time)
+
+        time += datetime.timedelta(seconds=1)
+        self.enqueue_job(QUEUE, args=['args1'], created_time=time)
+
+        # sanity check
+        self.assertEqual(
+            6,
+            self.backend.length(QUEUE),
+        )
+
+        result = self.backend.deduplicate(QUEUE)
+        self.assertEqual(
+            (6, 3),
+            result,
+            "Should remove duplicate entries from queue",
+        )
+
+        self.assertEqual(
+            3,
+            self.backend.length(QUEUE),
+            "Wrong number of jobs remaining in queue"
+        )
+
+        job = self.backend.dequeue(QUEUE, WORKER_NUMBER, timeout=1)
+        self.assertEqual(
+            ['args1'],
+            job.args,
+            "First job dequeued should be the first job enqueued",
+        )
+
+        self.backend.processed_job(QUEUE, WORKER_NUMBER, job)
+
+        job = self.backend.dequeue(QUEUE, WORKER_NUMBER, timeout=1)
+        self.assertEqual(
+            ['args2'],
+            job.args,
+            "Second job dequeued should be the second job enqueued",
+        )
+
+        self.backend.processed_job(QUEUE, WORKER_NUMBER, job)
+
+        job = self.backend.dequeue(QUEUE, WORKER_NUMBER, timeout=1)
+        self.assertEqual(
+            ['args3'],
+            job.args,
+            "Third job dequeued should be the third job enqueued",
+        )

--- a/tests/test_reliable_redis_backend.py
+++ b/tests/test_reliable_redis_backend.py
@@ -2,7 +2,8 @@ import datetime
 import unittest
 
 from django_lightweight_queue.job import Job
-from django_lightweight_queue.backends.reliable_redis import ReliableRedisBackend
+from django_lightweight_queue.backends.reliable_redis import \
+    ReliableRedisBackend
 
 from . import settings
 from .mixins import RedisCleanupMixin


### PR DESCRIPTION
We ignore the created timestamp as that doesn't actually affect the jobs and is present only for logging purposes.

Note: I've not yet tested the command; I plan to do that tomorrow if I have time.