### PR TITLE
Reduce startup duplication

### DIFF
--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -54,6 +54,7 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
     # Some backends may require on-startup logic per-queue, initialise a dummy
     # backend per queue to do so.
     for queue, _ in machine.worker_names:
+        log.info("Running startup for queue %s", queue)
         backend = get_backend(queue)
         backend.startup(queue)
 

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -53,7 +53,8 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
 
     # Some backends may require on-startup logic per-queue, initialise a dummy
     # backend per queue to do so.
-    for queue, _ in machine.worker_names:
+    queues_to_startup = set(q for q, _ in machine.worker_names)
+    for queue in queues_to_startup:
         log.info("Running startup for queue %s", queue)
         backend = get_backend(queue)
         backend.startup(queue)


### PR DESCRIPTION
Only run startup for each queue once on each machine
    
Previously we ran startup on the queue for each worker, which potentially meant running startup for the same queue several times if there were several queue workers for a given queue on a given machine.
