### PR TITLE
Avoid race between master shutdown and wokers' sigkill_on_stop

### DIFF
--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -132,6 +132,10 @@ class Worker(multiprocessing.Process):
             job.sigkill_on_stop,
         )
 
+        # Avoid race condition around whether we can be killed
+        if not self.running.value:
+            return False
+
         self.log.debug("Running job %s", job)
         self.set_process_title("Running job %s" % job)
 


### PR DESCRIPTION
If the master process needs to stop running while the worker process is fetching a job, then it could fall out of its running loop before it has received the message from the worker that the worker is no
longer `sigkill_on_stop`. This could lead to a non-sigkillable task being killed undesirably.

Avoid this by adding a check against the running flag _after_ the worker has told the master about the state change, but _before_ the worker actually starts the task.

This potentially leaves the task itself dequeued but unprocessed, however that is already something that the backends need to cope with.