### PR TITLE
Call proper request handler

### DIFF
--- a/django_lightweight_queue/exposition.py
+++ b/django_lightweight_queue/exposition.py
@@ -65,7 +65,7 @@ def start_master_http_server(running, worker_queue_and_counts):
             httpd.timeout = 5
 
             while self.running.value:
-                httpd.handle_one_request()
+                httpd.handle_request()
 
     t = MetricsServer(running, name="Master Prometheus metrics server")
     t.daemon = True


### PR DESCRIPTION
This appears to have been the proper method to be calling, even under Python 2 ('handle_one_request' doesn't even exist under Python 3).

Despite testing locally I've been unable to reproduce the issues we hit when attempting to use this method in the past, so I suspect that enough other things in the system may have change that they're no longer an issue. Hopefully.