### PR TITLE
Communicate between processes using IPC

### DIFF
--- a/django_lightweight_queue/cron_scheduler.py
+++ b/django_lightweight_queue/cron_scheduler.py
@@ -50,6 +50,8 @@ class CronScheduler(multiprocessing.Process):
         self.log.info("Loaded backend %s", backend)
 
         while True:
+            # This will run until terminated by the master process via
+            # a signal.
             try:
                 self.tick(backend)
 

--- a/django_lightweight_queue/cron_scheduler.py
+++ b/django_lightweight_queue/cron_scheduler.py
@@ -61,8 +61,6 @@ class CronScheduler(multiprocessing.Process):
             except KeyboardInterrupt:
                 sys.exit(1)
 
-        self.log.info("Exiting")
-
     def tick(self, backend):
         self.log.debug("tick()")
 

--- a/django_lightweight_queue/cron_scheduler.py
+++ b/django_lightweight_queue/cron_scheduler.py
@@ -17,8 +17,7 @@ CRON_QUEUE_NAME = 'cron_scheduler'
 
 
 class CronScheduler(multiprocessing.Process):
-    def __init__(self, running, log_level, log_filename, config):
-        self.running = running
+    def __init__(self, log_level, log_filename, config):
         self.log_level = log_level
         self.log_filename = log_filename
         self.config = config
@@ -50,7 +49,7 @@ class CronScheduler(multiprocessing.Process):
         backend = get_backend(CRON_QUEUE_NAME)
         self.log.info("Loaded backend %s", backend)
 
-        while self.running.value:
+        while True:
             try:
                 self.tick(backend)
 

--- a/django_lightweight_queue/exposition.py
+++ b/django_lightweight_queue/exposition.py
@@ -64,7 +64,7 @@ def start_master_http_server(running, worker_queue_and_counts):
             # Required as handle_request blocks without this
             httpd.timeout = 5
 
-            while self.running.value:
+            while self.running:
                 httpd.handle_request()
 
     t = MetricsServer(running, name="Master Prometheus metrics server")

--- a/django_lightweight_queue/exposition.py
+++ b/django_lightweight_queue/exposition.py
@@ -1,4 +1,5 @@
 import json
+import signal
 import multiprocessing
 
 from socket import gethostname
@@ -35,7 +36,7 @@ def get_config_response(worker_queue_and_counts):
         for index, (queue, worker_num) in enumerate(worker_queue_and_counts, start=1)
     ]
 
-def start_master_http_server(running, worker_queue_and_counts):
+def metrics_http_server(worker_queue_and_counts):
     config_response = json.dumps(
         get_config_response(worker_queue_and_counts),
         sort_keys=True,
@@ -43,6 +44,7 @@ def start_master_http_server(running, worker_queue_and_counts):
     ).encode('utf-8')
 
     class RequestHandler(MetricsHandler, object):
+
         def do_GET(self):
             if self.path == "/worker_config":
                 self.send_response(200)
@@ -53,20 +55,17 @@ def start_master_http_server(running, worker_queue_and_counts):
             return super(RequestHandler, self).do_GET()
 
     class MetricsServer(multiprocessing.Process):
-        def __init__(self, running, *args, **kwargs):
-            self.running = running
+        def __init__(self, *args, **kwargs):
             super(MetricsServer, self).__init__(*args, **kwargs)
 
         def run(self):
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
             set_process_title("Root Prometheus metrics server")
             httpd = HTTPServer(('0.0.0.0', app_settings.PROMETHEUS_START_PORT), RequestHandler)
 
-            # Required as handle_request blocks without this
-            httpd.timeout = 5
+            try:
+                httpd.serve_forever()
+            except KeyboardInterrupt:
+                pass
 
-            while self.running:
-                httpd.handle_request()
-
-    t = MetricsServer(running, name="Master Prometheus metrics server")
-    t.daemon = True
-    t.start()
+    return MetricsServer(name="Master Prometheus metrics server")

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -89,9 +89,10 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
 
         time.sleep(1)
 
-    # The cron scheduler is always safe to kill.
-    os.kill(cron_scheduler.pid, signal.SIGKILL)
-    cron_scheduler.join()
+    if machine.run_cron:
+        # The cron scheduler is always safe to kill.
+        os.kill(cron_scheduler.pid, signal.SIGKILL)
+        cron_scheduler.join()
 
     def signal_workers(signum):
         for worker in workers.values():

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -11,7 +11,7 @@ except ImportError:
 from . import app_settings
 from .utils import set_process_title, get_backend
 from .worker import Worker
-from .exposition import start_master_http_server
+from .exposition import metrics_http_server
 from .cron_scheduler import CronScheduler, CRON_QUEUE_NAME, get_cron_config, \
     ensure_queue_workers_for_config
 
@@ -58,7 +58,8 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
     workers = {x: None for x in machine.worker_names}
 
     if app_settings.ENABLE_PROMETHEUS:
-        start_master_http_server(running, machine.worker_names)
+        metrics_server = metrics_http_server(machine.worker_names)
+        metrics_server.start()
 
     while running:
         for index, (queue, worker_num) in enumerate(machine.worker_names, start=1):
@@ -114,5 +115,10 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
             continue
         log.info("Waiting for %s to terminate", worker.name)
         worker.join()
+
+    if app_settings.ENABLE_PROMETHEUS:
+        metrics_server.terminate()
+        log.info("Waiting for metrics server to terminate")
+        metrics_server.join()
 
     log.info("All processes finished; returning")

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -94,12 +94,9 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
     os.kill(cron_scheduler.pid, signal.SIGKILL)
     cron_scheduler.join()
 
-    def signal_workers(signum, condition):
+    def signal_workers(signum):
         for worker in workers.values():
             if worker is None:
-                continue
-
-            if not condition(worker):
                 continue
 
             try:
@@ -110,7 +107,7 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
     # SIGUSR2 all the workers. This sets a flag asking them to shut down
     # gracefully, or kills them immediately if they are receptive to that
     # sort of abuse.
-    signal_workers(signal.SIGUSR2, lambda worker: True)
+    signal_workers(signal.SIGUSR2)
 
     for worker in workers.values():
         if worker is None:

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -156,7 +156,8 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
                 pass
 
     # SIGUSR2 all the workers. This sets a flag asking them to shut down
-    # gracefully.
+    # gracefully, or kills them immediately if they are receptive to that
+    # sort of abuse.
     signal_workers(signal.SIGUSR2, lambda worker: True)
 
     # Kill all the killable workers. While we could do this second and thus give

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -147,11 +147,13 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
             if worker is None:
                 continue
 
-            if condition(worker):
-                try:
-                    os.kill(worker.pid, signum)
-                except OSError:
-                    pass
+            if not condition(worker):
+                continue
+
+            try:
+                os.kill(worker.pid, signum)
+            except OSError:
+                pass
 
     # SIGUSR2 all the workers. This sets a flag asking them to shut down
     # gracefully.

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -142,9 +142,6 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
     os.kill(cron_scheduler.pid, signal.SIGKILL)
     cron_scheduler.join()
 
-    # Filter out workers which might not have yet been started
-    alive_workers = [x for x in workers.values() if x is not None]
-
     def signal_workers(signum, condition):
         for worker in workers.values():
             if worker is None:
@@ -162,7 +159,9 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
     # the master could be killed while we're trying to tidy up.
     signal_workers(signal.SIGKILL, lambda worker: worker.sigkill_on_stop)
 
-    for worker in alive_workers:
+    for worker in workers.values():
+        if worker is None:
+            continue
         log.info("Waiting for %s to terminate", worker.name)
         worker.join()
 

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -138,7 +138,7 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
 
         time.sleep(1)
 
-    # The cron scheduler is always safe to kill
+    # The cron scheduler is always safe to kill.
     os.kill(cron_scheduler.pid, signal.SIGKILL)
     cron_scheduler.join()
 

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -79,7 +79,6 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
                     queue,
                     index,
                     worker_num,
-                    running,
                     log.level,
                     log_filename_fn('%s.%s' % (queue, worker_num)),
                     touch_filename_fn(queue),

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -57,7 +57,6 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
 
     if machine.run_cron:
         cron_scheduler = CronScheduler(
-            running,
             log.level,
             log_filename_fn(CRON_QUEUE_NAME),
             cron_config,
@@ -138,6 +137,10 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
             worker.sigkill_on_stop = sigkill_on_stop
 
         time.sleep(1)
+
+    # The cron scheduler is always safe to kill
+    os.kill(cron_scheduler.pid, signal.SIGKILL)
+    cron_scheduler.join()
 
     # Filter out workers which might not have yet been started
     alive_workers = [x for x in workers.values() if x is not None]

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -23,12 +23,11 @@ if app_settings.ENABLE_PROMETHEUS:
     )
 
 class Worker(multiprocessing.Process):
-    def __init__(self, queue, worker_index, worker_num, back_channel, log_level, log_filename, touch_filename):
+    def __init__(self, queue, worker_index, worker_num, log_level, log_filename, touch_filename):
         self.queue = queue
         self.worker_index = worker_index
         self.worker_num = worker_num
 
-        self.back_channel = back_channel
         self.running = True
 
         self.log_level = log_level
@@ -176,13 +175,6 @@ class Worker(multiprocessing.Process):
         else:
             # Cancel any scheduled alarms
             signal.alarm(0)
-
-        self.back_channel.put((
-            self.queue,
-            self.worker_num,
-            timeout,
-            sigkill_on_stop,
-        ))
 
     def set_process_title(self, *titles):
         set_process_title(self.name, *titles)

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -161,7 +161,8 @@ class Worker(multiprocessing.Process):
     def tell_master(self, timeout, sigkill_on_stop):
         if sigkill_on_stop:
             # SIGUSR2 can be taken to just cause the process to die
-            # immediately.
+            # immediately. This is the default action for SIGUSR2.
+            # Reference: signal(7)
             signal.signal(signal.SIGUSR2, signal.SIG_DFL)
         else:
             # SIGUSR2 indicates we should shut down after handling the

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -123,7 +123,6 @@ class Worker(multiprocessing.Process):
         self.log.debug("Checking backend for items")
         self.set_process_title("Waiting for items")
 
-        # Tell master process that we are not processing anything.
         self.configure_cancellation(timeout=None, sigkill_on_stop=True)
 
         job = backend.dequeue(self.queue, self.worker_num, 15)

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -124,16 +124,16 @@ class Worker(multiprocessing.Process):
         self.set_process_title("Waiting for items")
 
         # Tell master process that we are not processing anything.
-        self.tell_master(None, True)
+        self.configure_cancellation(timeout=None, sigkill_on_stop=True)
 
         job = backend.dequeue(self.queue, self.worker_num, 15)
         if job is None:
             return False
 
         # Update master what we are doing
-        self.tell_master(
-            job.timeout,
-            job.sigkill_on_stop,
+        self.configure_cancellation(
+            timeout=job.timeout,
+            sigkill_on_stop=job.sigkill_on_stop,
         )
 
         self.log.debug("Running job %s", job)
@@ -158,7 +158,7 @@ class Worker(multiprocessing.Process):
 
         return True
 
-    def tell_master(self, timeout, sigkill_on_stop):
+    def configure_cancellation(self, timeout, sigkill_on_stop):
         if sigkill_on_stop:
             # SIGUSR2 can be taken to just cause the process to die
             # immediately. This is the default action for SIGUSR2.


### PR DESCRIPTION
This is in preparation for changing the worker mechanism to spin up subprocesses rather than using multiprocessing. In short, multiprocessing and threads do not mix well, and on now two occasions we have been bitten by libraries starting background threads in the master process.

A prerequisite to switching over to subprocesses is moving away from multiprocessing's IPC mechanisms. This is that PR.

Previously we used IPC to essentially signal three things:

- Signalling from the master to the workers to gracefully shut down,
- Signalling from the workers to the master that they can be SIGKILLed,
- Signalling from the workers to the master requesting a timeout.

The timeout mechanism is replaced here by using `alarm(3)`, which means that the worker processes do not need to involve the master process in timing out.

The other two mechanisms are replaced by the master process sending `SIGUSR2` to worker processes. In situations where previously a worker process would have indicated to the master that it _could_ be SIGKILLed, the worker process instead installs the default signal handler for `SIGUSR2` which causes it to die. In situations where previously a worker process would have indicated to the master that it _could not_ be SIGKILLed, the worker process installs a signal handler setting a flag which will cause it to exit gracefully after the current job.