### PR TITLE
Run workers in subprocesses rather than multiprocessing

### DIFF
--- a/django_lightweight_queue/cron_scheduler.py
+++ b/django_lightweight_queue/cron_scheduler.py
@@ -61,8 +61,6 @@ class CronScheduler(multiprocessing.Process):
             except KeyboardInterrupt:
                 sys.exit(1)
 
-        self.log.info("Exiting")
-
     def tick(self, backend):
         self.log.debug("tick()")
 

--- a/django_lightweight_queue/exposition.py
+++ b/django_lightweight_queue/exposition.py
@@ -11,7 +11,7 @@ except ImportError:
 from prometheus_client.exposition import MetricsHandler
 
 from . import app_settings
-from .utils import set_process_title
+
 
 def get_config_response(worker_queue_and_counts):
     """
@@ -34,6 +34,7 @@ def get_config_response(worker_queue_and_counts):
         }
         for index, (queue, worker_num) in enumerate(worker_queue_and_counts, start=1)
     ]
+
 
 def metrics_http_server(worker_queue_and_counts):
     config_response = json.dumps(
@@ -65,4 +66,4 @@ def metrics_http_server(worker_queue_and_counts):
             except KeyboardInterrupt:
                 pass
 
-    return MetricsServer(name="Master Prometheus metrics server")
+    return MetricsServer(name="Master Prometheus metrics server", daemon=True)

--- a/django_lightweight_queue/management/commands/queue_worker.py
+++ b/django_lightweight_queue/management/commands/queue_worker.py
@@ -2,7 +2,7 @@ import sys
 import logging
 import argparse
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from ...worker import Worker
 
@@ -34,11 +34,13 @@ class Command(BaseCommand):
         parser.add_argument(
             '--log-file',
             type=str,
+            dest='log_filename',
             help="log destination",
         )
         parser.add_argument(
             '--touch-file',
-            type=argparse.FileType('ab'),
+            type=str,
+            dest='touch_filename',
             default=None,
             help="file to touch after jobs",
         )
@@ -49,8 +51,8 @@ class Command(BaseCommand):
         number,
         prometheus_port,
         log_level,
-        log_file,
-        touch_file,
+        log_filename,
+        touch_filename,
         **options
     ):
         worker = Worker(
@@ -58,7 +60,7 @@ class Command(BaseCommand):
             worker_num=number,
             prometheus_port=prometheus_port,
             log_level=logging._nameToLevel[log_level.upper()],
-            log_file=log_file,
-            touch_file=touch_file,
+            log_filename=log_filename,
+            touch_filename=touch_filename,
         )
         worker.run()

--- a/django_lightweight_queue/management/commands/queue_worker.py
+++ b/django_lightweight_queue/management/commands/queue_worker.py
@@ -1,0 +1,64 @@
+import sys
+import logging
+import argparse
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ...worker import Worker
+
+
+class Command(BaseCommand):
+    help = "Run an individual queue worker"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'queue',
+            help="queue for which this is a worker",
+        )
+        parser.add_argument(
+            'number',
+            type=int,
+            help="worker number within this queue",
+        )
+        parser.add_argument(
+            '--prometheus-port',
+            type=int,
+            help="port number on which to run Prometheus",
+        )
+        parser.add_argument(
+            '--log-level',
+            choices=[x.lower() for x in logging._nameToLevel.keys()],
+            default='warning',
+            help="log level to set",
+        )
+        parser.add_argument(
+            '--log-file',
+            type=str,
+            help="log destination",
+        )
+        parser.add_argument(
+            '--touch-file',
+            type=argparse.FileType('ab'),
+            default=None,
+            help="file to touch after jobs",
+        )
+
+    def handle(
+        self,
+        queue,
+        number,
+        prometheus_port,
+        log_level,
+        log_file,
+        touch_file,
+        **options
+    ):
+        worker = Worker(
+            queue=queue,
+            worker_num=number,
+            prometheus_port=prometheus_port,
+            log_level=logging._nameToLevel[log_level.upper()],
+            log_file=log_file,
+            touch_file=touch_file,
+        )
+        worker.run()

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -97,10 +97,6 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
 
         time.sleep(1)
 
-    # The cron scheduler is always safe to kill.
-    os.kill(cron_scheduler.pid, signal.SIGKILL)
-    cron_scheduler.join()
-
     def signal_workers(signum):
         for worker in workers.values():
             if worker is None:

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -77,7 +77,7 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
 
                 worker = Worker(
                     queue,
-                    index,
+                    app_settings.PROMETHEUS_START_PORT + index,
                     worker_num,
                     running,
                     log.level,

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -59,7 +59,7 @@ def runner(log, log_filename_fn, touch_filename_fn, machine):
     workers = {x: None for x in machine.worker_names}
 
     if app_settings.ENABLE_PROMETHEUS:
-        start_master_http_server(running, machine.worker_names)
+        start_master_http_server(machine.worker_names)
 
     while running:
         for index, (queue, worker_num) in enumerate(machine.worker_names, start=1):

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -6,7 +6,6 @@ import signal
 import logging
 import datetime
 import itertools
-import multiprocessing
 
 from prometheus_client import start_http_server, Summary
 
@@ -22,7 +21,7 @@ if app_settings.ENABLE_PROMETHEUS:
         ['queue'],
     )
 
-class Worker(multiprocessing.Process):
+class Worker(object):
     def __init__(self, queue, prometheus_port, worker_num, log_level, log_filename, touch_filename):
         self.queue = queue
         self.prometheus_port = prometheus_port

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -23,9 +23,9 @@ if app_settings.ENABLE_PROMETHEUS:
     )
 
 class Worker(multiprocessing.Process):
-    def __init__(self, queue, worker_index, worker_num, log_level, log_filename, touch_filename):
+    def __init__(self, queue, prometheus_port, worker_num, log_level, log_filename, touch_filename):
         self.queue = queue
-        self.worker_index = worker_index
+        self.prometheus_port = prometheus_port
         self.worker_num = worker_num
 
         self.running = True
@@ -63,10 +63,9 @@ class Worker(multiprocessing.Process):
             },
         )
 
-        if app_settings.ENABLE_PROMETHEUS:
-            metrics_port = app_settings.PROMETHEUS_START_PORT + self.worker_index
-            self.log.info("Exporting metrics on port %d" % metrics_port)
-            start_http_server(metrics_port)
+        if app_settings.ENABLE_PROMETHEUS and self.prometheus_port is not None:
+            self.log.info("Exporting metrics on port %d" % self.prometheus_port)
+            start_http_server(self.prometheus_port)
 
         self.log.debug("Starting")
 


### PR DESCRIPTION
We've experienced multiple times an issue where Django apps or libraries start background threads. Threading and multiprocessing [do not mix][fork-threads]. Realistically rather than enforcing constraints on what can be mixed with DLQ or coming up with a half-setup where we don't initialise any app configs on the master process, it would be better to run the worker processes as subprocesses with the separation of a call to `execve(2)` in the interim.

This is not a total win–we do lose the benefit of copy-on-write and pay for a greater initialisation time. On the other hand, this provides better separation and makes no assumptions about threads.

There is also a side-benefit of being able to run an individual worker in the foreground.

Since there's now no prohibition on doing so this also moves the cron scheduler and master prometheus configuration into threads.

[fork-threads]: http://www.linuxprogrammingblog.com/threads-and-fork-think-twice-before-using-them