### PR TITLE
Add a view for running jobs in a rolled-back transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ present in the specified file are inherited from the global configuration.
 
 ### Backends
 
-There are three built-in backends:
+There are four built-in backends:
 - Synchronous (the default): executes the task inline, without any actual queuing
 - Redis: executes tasks at-most-once using [Redis][redis] for storage of the
   enqueued tasks
 - Reliable Redis: executes tasks at-least-once using [Redis][redis] for storage
   of the enqueued tasks
+- Debug Web: a backend for use in debugging. Instead of running jobs it prints
+  the url to a view that can be used to run a task in a transaction which will
+  be rolled back. This is useful for debugging and optimising tasks.
 
 [redis]: https://redis.io/
 

--- a/django_lightweight_queue/backends/debug_web.py
+++ b/django_lightweight_queue/backends/debug_web.py
@@ -1,0 +1,33 @@
+import urllib
+
+from django.conf import settings
+from django.shortcuts import reverse
+
+
+class DebugWebBackend(object):
+    """
+    This backend aids debugging in concert with the 'debug-run' view.
+
+    Instead of actually running a job, it prints the url to the debug-run view
+    for the local Django instance which can be used to run the task for
+    debugging.
+
+    See the docstring of that view for information (and limitations) about it.
+    """
+    def startup(self, queue):
+        pass
+
+    def enqueue(self, job, queue):
+        path = reverse('django-lightweight-queue:debug-run')
+        query_string = urllib.parse.urlencode({'job': job.to_json()})
+        url = "{}{}?{}".format(settings.SITE_URL, path, query_string)
+        print(url)
+
+    def dequeue(self, queue, worker_num, timeout):
+        pass
+
+    def length(self, queue):
+        return 0
+
+    def processed_job(self, queue, worker_num, job):
+        pass

--- a/django_lightweight_queue/urls.py
+++ b/django_lightweight_queue/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from . import views
+
+app_name = 'django_lightweight_queue'
+
+urlpatterns = (
+    url(r'^debug/django-lightweight-queue/debug-run$', views.debug_run, name='debug-run'),
+)

--- a/django_lightweight_queue/views.py
+++ b/django_lightweight_queue/views.py
@@ -44,8 +44,8 @@ def debug_run(request):
 
     job = Job.from_json(request.GET['job'])
 
-    log_steam = io.StringIO()
-    handler = logging.StreamHandler(log_steam)
+    log_stream = io.StringIO()
+    handler = logging.StreamHandler(log_stream)
 
     try:
         logging.root.addHandler(handler)
@@ -72,7 +72,7 @@ def debug_run(request):
         'path': job.path,
         'job': json.dumps(job.as_dict(), sort_keys=True, indent=4),
         'result': result,
-        'log': log_steam.getvalue(),
+        'log': log_stream.getvalue(),
     }))
 
     return HttpResponse(document.encode('utf-8'))

--- a/django_lightweight_queue/views.py
+++ b/django_lightweight_queue/views.py
@@ -1,0 +1,78 @@
+import io
+import json
+import logging
+
+from django import template
+from django.db import transaction
+from django.conf import settings
+from django.http import Http404, HttpResponse
+
+from .job import Job
+
+
+# Note: no authentication here -- ensure you only connect up this view in
+# development!
+def debug_run(request):
+    """
+    Run a task on a `GET` request and within a transaction which will always be
+    rolled back.
+
+    This is useful for debugging tasks and for optimising their database
+    accesses (via the Django Debug Toolbar).
+
+    Logging output from the task is captured and included on the page, though
+    `print` calls are not.
+
+    You should take care when using this to debug tasks which interact with
+    services other than the database (e.g: caches or HTTP endpoints), as *only*
+    the database transaction is rolled back after the task completes. Any other
+    external requests will happen as normal.
+
+    To make this view available you'll need to have your main Django project
+    include its url somewhere. You are *strongly* encouraged only to do this in
+    DEBUG mode:
+    ```
+    if settings.DEBUG:
+        urlpatterns += (
+            url(r'', include('django_lightweight_queue.urls', namespace='django-lightweight-queue')),
+        )
+    ```
+    """
+
+    if not settings.DEBUG:
+        raise Http404("Debug view only available when DEBUG=True")
+
+    job = Job.from_json(request.GET['job'])
+
+    log_steam = io.StringIO()
+    handler = logging.StreamHandler(log_steam)
+
+    try:
+        logging.root.addHandler(handler)
+        with transaction.atomic():
+            result = job.run()
+            transaction.set_rollback(rollback=True)
+    finally:
+        logging.root.removeHandler(handler)
+
+    document = template.Template("""
+    <!doctype html>
+    <html>
+        <head>
+            <title>Debug Run {{ path }}</title>
+        </head>
+        <body>
+            <h2>Debug Run {{ path }}</h2>
+            <p><strong>Result:</strong> {{ result }}</p>
+            <code><pre>{{ job }}</pre></code>
+            <code><pre>{{ log }}</pre></code>
+        </body>
+    </html>
+    """).render(template.Context({
+        'path': job.path,
+        'job': json.dumps(job.as_dict(), sort_keys=True, indent=4),
+        'result': result,
+        'log': log_steam.getvalue(),
+    }))
+
+    return HttpResponse(document.encode('utf-8'))


### PR DESCRIPTION
This is useful for developing and debugging them as well as (if you have Django Debug Toolbar installed) optimising their database queries.