### PR TITLE
Test on more python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
   restore-dependencies-cache: &restore-dependencies-cache
     restore_cache:
       keys:
-        - deps-{{ checksum "poetry.lock" }}
+        - deps-py<< parameters.version >>-{{ checksum "poetry.lock" }}
   install-dependencies: &install-dependencies
     run:
       name: Install Dependencies
@@ -18,14 +18,24 @@ references:
         poetry install
   save-dependencies-cache: &save-dependencies-cache
     save_cache:
-      key: deps-{{ checksum "poetry.lock" }}
+      key: deps-py<< parameters.version >>-{{ checksum "poetry.lock" }}
       paths:
         - /home/circleci/.cache/pypoetry/virtualenvs
 
+executors:
+  python:
+    parameters:
+      version:
+        type: string
+    docker:
+      - image: circleci/python:<< parameters.version >>
+
 jobs:
   build-test:
-    docker:
-      - image: circleci/python:3.5.5
+    executor:
+      name: python
+      version: "3.5.5"
+
     steps:
       - checkout
 
@@ -41,8 +51,10 @@ jobs:
             poetry run ./runtests
 
   lint:
-    docker:
-      - image: circleci/python:3.5.5
+    executor:
+      name: python
+      version: "3.5.5"
+
     steps:
       - checkout
 
@@ -58,8 +70,9 @@ jobs:
             poetry run flake8
 
   deploy:
-    docker:
-      - image: circleci/python:3.5.5
+    executor:
+      name: python
+      version: "3.5.5"
     steps:
       - checkout
       - run:
@@ -80,6 +93,7 @@ workflows:
     jobs:
       - build-test
       - lint
+
 
   build-test-deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,17 @@ references:
       key: deps-py<< parameters.version >>-{{ checksum "poetry.lock" }}
       paths:
         - /home/circleci/.cache/pypoetry/virtualenvs
+  parametrised-python-executor: &parametrised-python-executor
+    parameters:
+      version:
+        type: string
+    executor:
+      name: python
+      version: << parameters.version >>
+  python-version-matrix: &python-version-matrix
+    matrix:
+      parameters:
+        version: ["3.5.5"]
 
 executors:
   python:
@@ -32,9 +43,7 @@ executors:
 
 jobs:
   build-test:
-    executor:
-      name: python
-      version: "3.5.5"
+    <<: *parametrised-python-executor
 
     steps:
       - checkout
@@ -51,9 +60,7 @@ jobs:
             poetry run ./runtests
 
   lint:
-    executor:
-      name: python
-      version: "3.5.5"
+    <<: *parametrised-python-executor
 
     steps:
       - checkout
@@ -91,13 +98,16 @@ workflows:
 
   build-test:
     jobs:
-      - build-test
-      - lint
+      - build-test:
+          <<: *python-version-matrix
+      - lint:
+          <<: *python-version-matrix
 
 
   build-test-deploy:
     jobs:
       - build-test:
+          <<: *python-version-matrix
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
@@ -105,6 +115,7 @@ workflows:
               ignore: /.*/
 
       - lint:
+          <<: *python-version-matrix
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ references:
   python-version-matrix: &python-version-matrix
     matrix:
       parameters:
-        version: ["3.5.5"]
+        version: ["3.5.5", "3.6", "3.7", "3.8"]
 
 executors:
   python:


### PR DESCRIPTION
Based on the `linting` branch (#35) to avoid conflicts, though otherwise unrelated.

This converts the Circle CI build config to use matrix builds and then introduces testing on more recent Python versions.