### PR TITLE
Add progress output when deduplicating jobs

### DIFF
--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -3,7 +3,7 @@ import redis
 from .. import app_settings
 from ..job import Job
 from .base import BaseBackend
-from ..logger import NULL_LOGGER
+from ..progress_logger import NULL_PROGRESS_LOGGER
 
 
 class ReliableRedisBackend(BaseBackend):
@@ -106,7 +106,7 @@ class ReliableRedisBackend(BaseBackend):
     def length(self, queue):
         return self.client.llen(self._key(queue))
 
-    def deduplicate(self, queue, *, logger=NULL_LOGGER):
+    def deduplicate(self, queue, *, progress_logger=NULL_PROGRESS_LOGGER):
         """
         Deduplicate the given queue by comparing the jobs in a manner which
         ignores their created timestamps.
@@ -129,18 +129,18 @@ class ReliableRedisBackend(BaseBackend):
         # latter list are ordered from newest to oldest
         jobs = {}
 
-        logger.info("Collecting jobs")
+        progress_logger.info("Collecting jobs")
 
-        for raw_data in logger.progress(self.client.lrange(main_queue_key, 0, -1)):
+        for raw_data in progress_logger.progress(self.client.lrange(main_queue_key, 0, -1)):
             job_identity = Job.from_json(
                 raw_data.decode('utf-8'),
             ).identity_without_created()
 
             jobs.setdefault(job_identity, []).append(raw_data)
 
-        logger.info("Removing duplicate jobs")
+        progress_logger.info("Removing duplicate jobs")
 
-        for raw_jobs in logger.progress(jobs.values()):
+        for raw_jobs in progress_logger.progress(jobs.values()):
             # Leave the oldest in the queue
             for raw_data in raw_jobs[:-1]:
                 # Remove only one instance of this data (thus coping with

--- a/django_lightweight_queue/logger.py
+++ b/django_lightweight_queue/logger.py
@@ -1,0 +1,10 @@
+from typing import TypeVar, Callable, Iterable, NamedTuple
+
+T = TypeVar('T')
+
+Logger = NamedTuple('Logger', [
+    ('info', Callable[[str], None]),
+    ('progress', Callable[[Iterable[T]], Iterable[T]]),
+])
+
+NULL_LOGGER = Logger(lambda x: None, lambda x: x)

--- a/django_lightweight_queue/management/commands/queue_deduplicate.py
+++ b/django_lightweight_queue/management/commands/queue_deduplicate.py
@@ -3,7 +3,7 @@ from typing import TypeVar
 from django.core.management.base import BaseCommand, CommandError
 
 from ...utils import get_backend
-from ...logger import Logger
+from ...progress_logger import ProgressLogger
 
 T = TypeVar('T')
 
@@ -31,7 +31,7 @@ class Command(BaseCommand):
 
         original_size, new_size = backend.deduplicate(
             queue,
-            logger=self.get_logger(),
+            progress_logger=self.get_progress_logger(),
         )
 
         if original_size == new_size:
@@ -48,7 +48,7 @@ class Command(BaseCommand):
                 ),
             )
 
-    def get_logger(self) -> Logger:
+    def get_progress_logger(self) -> ProgressLogger:
         try:
             import tqdm
             progress = tqdm.tqdm
@@ -56,4 +56,4 @@ class Command(BaseCommand):
             def progress(iterable: T) -> T:
                 return iterable
 
-        return Logger(self.stdout.write, progress)
+        return ProgressLogger(self.stdout.write, progress)

--- a/django_lightweight_queue/progress_logger.py
+++ b/django_lightweight_queue/progress_logger.py
@@ -2,9 +2,9 @@ from typing import TypeVar, Callable, Iterable, NamedTuple
 
 T = TypeVar('T')
 
-Logger = NamedTuple('Logger', [
+ProgressLogger = NamedTuple('ProgressLogger', [
     ('info', Callable[[str], None]),
     ('progress', Callable[[Iterable[T]], Iterable[T]]),
 ])
 
-NULL_LOGGER = Logger(lambda x: None, lambda x: x)
+NULL_PROGRESS_LOGGER = ProgressLogger(lambda x: None, lambda x: x)

--- a/poetry.lock
+++ b/poetry.lock
@@ -330,6 +330,17 @@ docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "
 test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
 
 [[package]]
+category = "main"
+description = "Fast, Extensible Progress Meter"
+name = "tqdm"
+optional = true
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "4.54.1"
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown", "wheel"]
+
+[[package]]
 category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
@@ -344,9 +355,10 @@ testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [extras]
 redis = ["redis"]
+progress = ["tqdm"]
 
 [metadata]
-content-hash = "1e7dc43c5158b3cfc08f22167392fe026c6b2713161d7f6366235711c0400c57"
+content-hash = "3650964a49d975ad16401115c3c7d85da0f2d47a2b170ad34aeac1766cd70010"
 python-versions = ">=3.5"
 
 [metadata.files]
@@ -459,6 +471,10 @@ sqlparse = [
 testfixtures = [
     {file = "testfixtures-6.14.1-py2.py3-none-any.whl", hash = "sha256:30566e24a1b34e4d3f8c13abf62557d01eeb4480bcb8f1745467bfb0d415a7d9"},
     {file = "testfixtures-6.14.1.tar.gz", hash = "sha256:58d2b3146d93bc5ddb0cd24e0ccacb13e29bdb61e5c81235c58f7b8ee4470366"},
+]
+tqdm = [
+    {file = "tqdm-4.54.1-py2.py3-none-any.whl", hash = "sha256:d4f413aecb61c9779888c64ddf0c62910ad56dcbe857d8922bb505d4dbff0df1"},
+    {file = "tqdm-4.54.1.tar.gz", hash = "sha256:38b658a3e4ecf9b4f6f8ff75ca16221ae3378b2e175d846b6b33ea3a20852cf5"},
 ]
 zipp = [
     {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,11 @@ django = ">=1.11.27,<3.0"
 daemonize = "~=2.5.0"
 prometheus-client = "~=0.7"
 redis = {version = "~=3.*", optional = true}
+tqdm = {version = "^4.54.1", optional = true}
 
 [tool.poetry.extras]
 redis = ["redis"]
+progress = ["tqdm"]
 
 [tool.poetry.dev-dependencies]
 # Testing tools


### PR DESCRIPTION
This introduces a simple logger interface so that callers can optionally pass in a message handler and a progress meter.
Supporting the progress meter is the goal here and that is also the reason we cannot simply use the default Python logging support.

Fixes https://github.com/thread/django-lightweight-queue/issues/40