### PR TITLE
Avoid redundant work in ReliableRedisBackend.startup

### DIFF
--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -3,7 +3,7 @@ import redis
 from .. import app_settings
 from ..job import Job
 from .base import BaseBackend
-from ..utils import get_all_worker_numbers
+from ..utils import get_worker_numbers
 from ..progress_logger import NULL_PROGRESS_LOGGER
 
 
@@ -49,7 +49,7 @@ class ReliableRedisBackend(BaseBackend):
         current_processing_queue_keys = set(self.client.keys(pattern))
         expected_processing_queue_keys = set(
             self._processing_key(queue, worker_number).encode()
-            for worker_number in get_all_worker_numbers()[queue]
+            for worker_number in get_worker_numbers(queue)
         )
         processing_queue_keys = current_processing_queue_keys - expected_processing_queue_keys
 

--- a/django_lightweight_queue/machine_types.py
+++ b/django_lightweight_queue/machine_types.py
@@ -1,6 +1,6 @@
 from django.utils.functional import cached_property
 
-from .utils import get_queue_counts
+from .utils import get_queue_counts, get_worker_numbers
 from .cron_scheduler import CRON_QUEUE_NAME
 
 
@@ -66,11 +66,11 @@ class PooledMachine(Machine):
         # choosing only those which should be run on this machine.
         job_number = 1
 
-        for queue, num_workers in sorted(get_queue_counts().items()):
+        for queue in sorted(get_queue_counts().keys()):
             if self.only_queue and self.only_queue != queue:
                 continue
 
-            for worker_num in range(1, num_workers + 1):
+            for worker_num in get_worker_numbers(queue):
                 if (job_number % self.machine_count) + 1 == self.machine_number:  # noqa: S001
                     worker_names.append((queue, worker_num))
 
@@ -98,6 +98,6 @@ class DirectlyConfiguredMachine(Machine):
     def worker_names(self):
         return tuple(
             (queue, worker_number)
-            for queue, num_workers in sorted(get_queue_counts().items())
-            for worker_number in range(num_workers)
+            for queue in sorted(get_queue_counts().keys())
+            for worker_number in get_worker_numbers(queue)
         )

--- a/django_lightweight_queue/utils.py
+++ b/django_lightweight_queue/utils.py
@@ -99,9 +99,9 @@ def get_queue_counts():
     return app_settings.WORKERS
 
 
-def get_all_worker_numbers() -> Mapping[str, Collection[int]]:
-    counts = get_queue_counts()
-    return {k: range(1, v + 1) for k, v in counts.items()}
+def get_worker_numbers(queue: str) -> Collection[int]:
+    count = get_queue_counts()[queue]
+    return range(1, count + 1)
 
 
 def import_all_submodules(name, exclude=()):

--- a/django_lightweight_queue/utils.py
+++ b/django_lightweight_queue/utils.py
@@ -1,7 +1,7 @@
 import imp
 import warnings
 import importlib
-from typing import Mapping
+from typing import Mapping, Collection
 from functools import lru_cache
 
 from django.apps import apps
@@ -97,6 +97,11 @@ def get_queue_counts():
     # type: (None) -> Mapping[str, int]
     refuse_further_implied_queues()
     return app_settings.WORKERS
+
+
+def get_all_worker_numbers() -> Mapping[str, Collection[int]]:
+    counts = get_queue_counts()
+    return {k: range(1, v + 1) for k, v in counts.items()}
 
 
 def import_all_submodules(name, exclude=()):


### PR DESCRIPTION
This aims to speed up queue startup when using this backend as we have seen in production that this can take a while.

In particular if a master process is restarted while other machines are still processing jobs then the startup on that machine can end up retrying the move of in-flight jobs repeatedly while racing against the valid processing by workers elsewhere.

This change limits the scope for this by inspecting the list of processing queues and comparing it to the list of expected queues in order to only rescue jobs from workers which no longer exist.