### PR TITLE
Add a mechanism to pause work on (redis) queues

### DIFF
--- a/django_lightweight_queue/backends/base.py
+++ b/django_lightweight_queue/backends/base.py
@@ -1,6 +1,9 @@
+import datetime
 from abc import ABCMeta, abstractmethod
 
 from ..job import Job
+
+QueueName = str
 
 
 class BaseBackend(metaclass=ABCMeta):
@@ -21,3 +24,15 @@ class BaseBackend(metaclass=ABCMeta):
 
     def processed_job(self, queue: str, worker_num: int, job: Job) -> None:
         pass
+
+
+class BackendWithPause(BaseBackend, metaclass=ABCMeta):
+    @abstractmethod
+    def pause(self, queue: QueueName, until: datetime.datetime) -> None:
+        raise NotImplementedError()
+
+
+class BackendWithPauseResume(BackendWithPause, metaclass=ABCMeta):
+    @abstractmethod
+    def resume(self, queue: QueueName) -> None:
+        raise NotImplementedError()

--- a/django_lightweight_queue/backends/base.py
+++ b/django_lightweight_queue/backends/base.py
@@ -47,6 +47,10 @@ class BackendWithPause(BaseBackend, metaclass=ABCMeta):
     def pause(self, queue: QueueName, until: datetime.datetime) -> None:
         raise NotImplementedError()
 
+    @abstractmethod
+    def is_paused(self, queue: QueueName) -> bool:
+        raise NotImplementedError()
+
 
 class BackendWithPauseResume(BackendWithPause, metaclass=ABCMeta):
     @abstractmethod

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -4,13 +4,13 @@ import redis
 
 from .. import app_settings
 from ..job import Job
-from .base import BaseBackend
+from .base import BackendWithPauseResume
 from ..utils import block_for_time
 
 QueueName = str
 
 
-class RedisBackend(BaseBackend):
+class RedisBackend(BackendWithPauseResume):
     """
     This backend has at-most-once semantics.
     """

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -69,7 +69,7 @@ class RedisBackend(BackendWithPauseResume):
         self.client.delete(self._pause_key(queue))
 
     def is_paused(self, queue: QueueName) -> bool:
-        return self.client.exists(self._pause_key(queue))
+        return bool(self.client.exists(self._pause_key(queue)))
 
     def _key(self, queue: QueueName) -> str:
         if app_settings.REDIS_PREFIX:

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -5,7 +5,7 @@ import redis
 
 from .. import app_settings
 from ..job import Job
-from .base import BaseBackend, BackendWithPauseResume
+from .base import BackendWithPauseResume
 from ..types import QueueName, WorkerNumber
 from ..utils import block_for_time
 

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -62,6 +62,12 @@ class RedisBackend(BaseBackend):
             value=until.isoformat(' '),
         )
 
+    def resume(self, queue: QueueName) -> None:
+        """
+        Resume the given queue by deleting the pause marker (if present).
+        """
+        self.client.delete(self._pause_key(queue))
+
     def is_paused(self, queue: QueueName) -> bool:
         return self.client.exists(self._pause_key(queue))
 

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -29,7 +29,7 @@ class RedisBackend(BaseBackend):
             # Block for a while to avoid constant polling ...
             block_for_time(
                 lambda: self.is_paused(queue),
-                timeout=datetime.timedelta(minutes=5),
+                timeout=datetime.timedelta(seconds=timeout),
             )
             # ... but always indicate that we did no work
             return None

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -212,7 +212,7 @@ class ReliableRedisBackend(BackendWithDeduplicate, BackendWithPauseResume):
         self.client.delete(self._pause_key(queue))
 
     def is_paused(self, queue: QueueName) -> bool:
-        return self.client.exists(self._pause_key(queue))
+        return bool(self.client.exists(self._pause_key(queue)))
 
     def _key(self, queue: QueueName) -> str:
         key = 'django_lightweight_queue:{}'.format(queue)

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -194,6 +194,12 @@ class ReliableRedisBackend(BaseBackend):
             value=until.isoformat(' '),
         )
 
+    def resume(self, queue: QueueName) -> None:
+        """
+        Resume the given queue by deleting the pause marker (if present).
+        """
+        self.client.delete(self._pause_key(queue))
+
     def is_paused(self, queue: QueueName) -> bool:
         return self.client.exists(self._pause_key(queue))
 

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -4,14 +4,14 @@ import redis
 
 from .. import app_settings
 from ..job import Job
-from .base import BaseBackend
+from .base import BackendWithPauseResume
 from ..utils import block_for_time, get_worker_numbers
 from ..progress_logger import NULL_PROGRESS_LOGGER
 
 QueueName = str
 
 
-class ReliableRedisBackend(BaseBackend):
+class ReliableRedisBackend(BackendWithPauseResume):
     """
     This backend manages a per-queue-per-worker 'processing' queue. E.g. if we
     had a queue called 'django_lightweight_queue:things', and two workers, we

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -94,7 +94,7 @@ class ReliableRedisBackend(BaseBackend):
             # Block for a while to avoid constant polling ...
             block_for_time(
                 lambda: self.is_paused(queue),
-                timeout=datetime.timedelta(minutes=5),
+                timeout=datetime.timedelta(seconds=timeout),
             )
             # ... but always indicate that we did no work
             return None

--- a/django_lightweight_queue/management/commands/queue_pause.py
+++ b/django_lightweight_queue/management/commands/queue_pause.py
@@ -5,6 +5,7 @@ import datetime
 from django.core.management.base import BaseCommand, CommandError
 
 from ...utils import get_backend
+from ...backends.base import BackendWithPause
 
 QueueName = str
 
@@ -79,7 +80,7 @@ class Command(BaseCommand):
 
         backend = get_backend(queue)
 
-        if not hasattr(backend, 'pause'):
+        if not isinstance(backend, BackendWithPause):
             raise CommandError(
                 "Configured backend '{}.{}' doesn't support pausing".format(
                     type(backend).__module__,

--- a/django_lightweight_queue/management/commands/queue_pause.py
+++ b/django_lightweight_queue/management/commands/queue_pause.py
@@ -1,0 +1,92 @@
+import re
+import argparse
+import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ...utils import get_backend
+
+QueueName = str
+
+DURATION_PATTERN = r'^((?P<hours>\d+)h)?((?P<minutes>\d+)m)?((?P<seconds>\d+)s)?$'
+TIME_FORMAT = r'%Y-%m-%dT%H:%M:%S%z'
+
+
+def utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def parse_duration_to_time(duration: str) -> datetime.datetime:
+    match = re.match(DURATION_PATTERN, duration)
+    if match is None:
+        raise ValueError(
+            f"Unknown duration format {duration!r}. Try something like '1h2m3s'.",
+        )
+
+    delta = datetime.timedelta(
+        hours=int(match['hours'] or 0),
+        minutes=int(match['minutes'] or 0),
+        seconds=int(match['seconds'] or 0),
+    )
+
+    return utcnow() + delta
+
+
+def parse_time(date_string: str) -> datetime.datetime:
+    return datetime.datetime.strptime(date_string, TIME_FORMAT)
+
+
+class Command(BaseCommand):
+    help = """
+    Command to pause work on a redis-backed queue.
+
+    New jobs can still be added to the queue, however no jobs will be pulled off
+    the queue for processing.
+    """  # noqa:A003 # inherited name
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            'queue',
+            action='store',
+            help="The queue to pause.",
+        )
+
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            '--for',
+            dest='until',
+            action='store',
+            type=parse_duration_to_time,
+            help=(
+                "The duration to pause the queue for. Specify a value like 1h2m3s, "
+                "all levels of precision are optional, so 5m and 1h are both valid."
+            ),
+        )
+        group.add_argument(
+            '--until',
+            action='store',
+            type=parse_time,
+            help=(
+                "The time at which the queue should reactivate. Specify as an "
+                "ISO 8601 value, specifically one parsable via datetime.strptime "
+                f"using {TIME_FORMAT!r}."
+            ),
+        )
+
+    def handle(self, queue: QueueName, until: datetime.datetime, **options: object) -> None:
+        if until < utcnow():
+            raise CommandError("Refusing to pause until a time in the past.")
+
+        backend = get_backend(queue)
+
+        if not hasattr(backend, 'pause'):
+            raise CommandError(
+                "Configured backend '{}.{}' doesn't support pausing".format(
+                    type(backend).__module__,
+                    type(backend).__name__,
+                ),
+            )
+
+        backend.pause(queue, until)
+
+        self.stdout.write(f"Paused queue {queue} until {until.isoformat(' ')}.")

--- a/django_lightweight_queue/management/commands/queue_pause.py
+++ b/django_lightweight_queue/management/commands/queue_pause.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
             help=(
                 "The time at which the queue should reactivate. Specify as an "
                 "ISO 8601 value, specifically one parsable via datetime.strptime "
-                f"using {TIME_FORMAT!r}."
+                f"using {TIME_FORMAT.replace('%', r'%%')!r}."
             ),
         )
 

--- a/django_lightweight_queue/management/commands/queue_pause.py
+++ b/django_lightweight_queue/management/commands/queue_pause.py
@@ -4,10 +4,9 @@ import datetime
 
 from django.core.management.base import BaseCommand, CommandError
 
+from ...types import QueueName
 from ...utils import get_backend
 from ...backends.base import BackendWithPause
-
-QueueName = str
 
 DURATION_PATTERN = r'^((?P<hours>\d+)h)?((?P<minutes>\d+)m)?((?P<seconds>\d+)s)?$'
 TIME_FORMAT = r'%Y-%m-%dT%H:%M:%S%z'

--- a/django_lightweight_queue/management/commands/queue_pause.py
+++ b/django_lightweight_queue/management/commands/queue_pause.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
             help=(
                 "The time at which the queue should reactivate. Specify as an "
                 "ISO 8601 value, specifically one parsable via datetime.strptime "
-                f"using {TIME_FORMAT.replace('%', r'%%')!r}."
+                f"using {TIME_FORMAT.replace('%', r'%%')!r}, such as {utcnow():{TIME_FORMAT}}."
             ),
         )
 

--- a/django_lightweight_queue/management/commands/queue_resume.py
+++ b/django_lightweight_queue/management/commands/queue_resume.py
@@ -2,10 +2,9 @@ import argparse
 
 from django.core.management.base import BaseCommand, CommandError
 
+from ...types import QueueName
 from ...utils import get_backend
 from ...backends.base import BackendWithPauseResume
-
-QueueName = str
 
 
 class Command(BaseCommand):

--- a/django_lightweight_queue/management/commands/queue_resume.py
+++ b/django_lightweight_queue/management/commands/queue_resume.py
@@ -3,6 +3,7 @@ import argparse
 from django.core.management.base import BaseCommand, CommandError
 
 from ...utils import get_backend
+from ...backends.base import BackendWithPauseResume
 
 QueueName = str
 
@@ -25,7 +26,7 @@ class Command(BaseCommand):
     def handle(self, queue: QueueName, **options: object) -> None:
         backend = get_backend(queue)
 
-        if not hasattr(backend, 'resume'):
+        if not isinstance(backend, BackendWithPauseResume):
             raise CommandError(
                 "Configured backend '{}.{}' doesn't support resuming from paused".format(
                     type(backend).__module__,

--- a/django_lightweight_queue/management/commands/queue_resume.py
+++ b/django_lightweight_queue/management/commands/queue_resume.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
 
         if not hasattr(backend, 'resume'):
             raise CommandError(
-                "Configured backend '{}.{}' doesn't support pausing".format(
+                "Configured backend '{}.{}' doesn't support resuming from paused".format(
                     type(backend).__module__,
                     type(backend).__name__,
                 ),

--- a/django_lightweight_queue/management/commands/queue_resume.py
+++ b/django_lightweight_queue/management/commands/queue_resume.py
@@ -1,0 +1,36 @@
+import argparse
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ...utils import get_backend
+
+QueueName = str
+
+
+class Command(BaseCommand):
+    help = """
+    Command to resume work immediately on a redis-backed queue.
+
+    This removes a pause which may be in place for the given queue, though it
+    may not cause workers to resume work immediately.
+    """  # noqa:A003 # inherited name
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            'queue',
+            action='store',
+            help="The queue to resume.",
+        )
+
+    def handle(self, queue: QueueName, **options: object) -> None:
+        backend = get_backend(queue)
+
+        if not hasattr(backend, 'resume'):
+            raise CommandError(
+                "Configured backend '{}.{}' doesn't support pausing".format(
+                    type(backend).__module__,
+                    type(backend).__name__,
+                ),
+            )
+
+        backend.resume(queue)

--- a/django_lightweight_queue/utils.py
+++ b/django_lightweight_queue/utils.py
@@ -138,12 +138,12 @@ def block_for_time(
 
     Returns whether or not the timeout was encountered.
     """
-    if not should_continue_blocking:
+    if not should_continue_blocking():
         return False
 
     end = time.time() + timeout.total_seconds()
 
-    while should_continue_blocking:
+    while should_continue_blocking():
         now = time.time()
         if now > end:
             # timed out

--- a/django_lightweight_queue/utils.py
+++ b/django_lightweight_queue/utils.py
@@ -14,7 +14,7 @@ from . import constants, app_settings
 
 _accepting_implied_queues = True
 
-THIRTY_SECONDS = datetime.timedelta(seconds=30)
+FIVE_SECONDS = datetime.timedelta(seconds=5)
 
 
 def load_extra_config(file_path):
@@ -131,7 +131,7 @@ def load_all_tasks():
 def block_for_time(
     should_continue_blocking: Callable[[], bool],
     timeout: datetime.timedelta,
-    check_frequency: datetime.timedelta = THIRTY_SECONDS,
+    check_frequency: datetime.timedelta = FIVE_SECONDS,
 ) -> bool:
     """
     Block until a cancellation function or timeout indicates otherwise.

--- a/poetry.lock
+++ b/poetry.lock
@@ -208,6 +208,17 @@ flake8 = ">=3.0,<3.2.0 || >3.2.0,<4"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
+name = "freezegun"
+version = "1.1.0"
+description = "Let your Python tests travel through time"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "importlib-metadata"
 version = "4.0.1"
 description = "Read metadata from Python packages"
@@ -298,6 +309,17 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "pytz"
@@ -411,7 +433,7 @@ redis = ["redis"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6"
-content-hash = "225614c9b143973d7f9de425fe30723c8b7156dcd998ee69cb79c92e5469b350"
+content-hash = "44461f804b2d6634e38d568b14367ddff0336c3987ee1a38af86cd0dec0cccd7"
 
 [metadata.files]
 asgiref = [
@@ -477,6 +499,10 @@ flake8-tidy-imports = [
     {file = "flake8-tidy-imports-4.2.1.tar.gz", hash = "sha256:52e5f2f987d3d5597538d5941153409ebcab571635835b78f522c7bf03ca23bc"},
     {file = "flake8_tidy_imports-4.2.1-py3-none-any.whl", hash = "sha256:76e36fbbfdc8e3c5017f9a216c2855a298be85bc0631e66777f4e6a07a859dc4"},
 ]
+freezegun = [
+    {file = "freezegun-1.1.0-py2.py3-none-any.whl", hash = "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"},
+    {file = "freezegun-1.1.0.tar.gz", hash = "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3"},
+]
 importlib-metadata = [
     {file = "importlib_metadata-4.0.1-py3-none-any.whl", hash = "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"},
     {file = "importlib_metadata-4.0.1.tar.gz", hash = "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581"},
@@ -520,6 +546,10 @@ pycodestyle = [
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ progress = ["tqdm"]
 [tool.poetry.dev-dependencies]
 # Testing tools
 fakeredis = "^1.1.0"
+freezegun = "^1.1.0"
 
 # Linting tools
 flake8 = "^3.8.0"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,7 @@
 SECRET_KEY = 'very-secret-value'
 
 LIGHTWEIGHT_QUEUE_REDIS_PREFIX = 'tests:'
+
+INSTALLED_APPS = [
+    'django_lightweight_queue',
+]

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -1,0 +1,120 @@
+import io
+import datetime
+import unittest
+from unittest import mock
+
+import fakeredis
+import freezegun
+from django_lightweight_queue.types import QueueName
+from django_lightweight_queue.utils import get_backend
+from django_lightweight_queue.backends.base import BackendWithPauseResume
+from django_lightweight_queue.backends.redis import RedisBackend
+from django_lightweight_queue.management.commands.queue_pause import (
+    parse_duration_to_time,
+)
+
+from django.core.management import (
+    call_command,
+    CommandError,
+    get_commands,
+    load_command_class,
+)
+
+
+class PauseResumeTests(unittest.TestCase):
+    longMessage = True
+
+    def assertPaused(self, queue: QueueName, context: str) -> None:
+        self.assertTrue(
+            self.backend.is_paused(queue),
+            f"{queue} should be pauseed {context}",
+        )
+
+    def assertNotPaused(self, queue: QueueName, context: str) -> None:
+        self.assertFalse(
+            self.backend.is_paused(queue),
+            f"{queue} should not be pauseed {context}",
+        )
+
+    def setUp(self) -> None:
+        get_backend.cache_clear()
+
+        redis_patch = mock.patch(
+            'redis.StrictRedis',
+            autospec=True,
+            return_value=fakeredis.FakeStrictRedis(),
+        )
+        redis_patch.start()
+        self.addCleanup(redis_patch.stop)
+
+        # Arbitrary choice of backend, just needs to match the one used in tests
+        self.backend: BackendWithPauseResume = RedisBackend()
+
+        super().setUp()
+
+    # Can't use override_settings due to the copying of the settings values into
+    # module values at startup.
+    @mock.patch(
+        'django_lightweight_queue.app_settings.BACKEND',
+        new='django_lightweight_queue.backends.redis.RedisBackend',
+    )
+    def test_pause_resume(self) -> None:
+        QUEUE = QueueName('test-pauseable-queue')
+        OTHER_QUEUE = QueueName('other-pauseable-queue')
+
+        self.assertNotPaused(QUEUE, "initially")
+        self.assertNotPaused(OTHER_QUEUE, "initially")
+
+        when = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=5)
+        buffer = io.StringIO()
+        # Work around https://code.djangoproject.com/ticket/33205 by bypassing
+        # the argument processing
+        queue_pause = load_command_class(get_commands()['queue_pause'], 'queue_pause')
+        defaults = {'no_color': None, 'force_color': None, 'skip_checks': True}
+        queue_pause.execute(QUEUE, until=when, stdout=buffer, **defaults)
+
+        self.assertPaused(QUEUE, "after being paused")
+        self.assertNotPaused(OTHER_QUEUE, f"after pausing {QUEUE}")
+
+        self.assertIn(QUEUE, buffer.getvalue())
+        self.assertIn(when.isoformat(' '), buffer.getvalue())
+
+        call_command('queue_resume', QUEUE)
+
+        self.assertNotPaused(QUEUE, "after being resumed")
+
+    def test_pause_resume_unsupported_backend(self) -> None:
+        QUEUE = QueueName('unsupported-queue')
+
+        when = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=5)
+        # Work around https://code.djangoproject.com/ticket/33205 by bypassing
+        # the argument processing
+        queue_pause = load_command_class(get_commands()['queue_pause'], 'queue_pause')
+        with self.assertRaises(CommandError):
+            queue_pause.handle(QUEUE, until=when)
+
+        with self.assertRaises(CommandError):
+            call_command('queue_resume', QUEUE)
+
+    @freezegun.freeze_time()
+    def test_parse_duration(self) -> None:
+        durations = [
+            ('3h', datetime.timedelta(hours=3)),
+            ('4m', datetime.timedelta(minutes=4)),
+            ('5s', datetime.timedelta(seconds=5)),
+            ('6h7s', datetime.timedelta(hours=6, seconds=7)),
+            ('2m8s', datetime.timedelta(minutes=2, seconds=8)),
+            ('6h7m', datetime.timedelta(hours=6, minutes=7)),
+            ('6h7m8s', datetime.timedelta(hours=6, minutes=7, seconds=8)),
+        ]
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        for duration, expected in durations:
+            with self.subTest(duration):
+                actual = parse_duration_to_time(duration) - now
+                self.assertEqual(
+                    expected,
+                    actual,
+                    f"Wrong duration parsed for {duration}",
+                )

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -14,12 +14,7 @@ from django_lightweight_queue.management.commands.queue_pause import (
     parse_duration_to_time,
 )
 
-from django.core.management import (
-    call_command,
-    CommandError,
-    get_commands,
-    load_command_class,
-)
+from django.core.management import call_command, CommandError
 
 
 class PauseResumeTests(unittest.TestCase):

--- a/tests/test_reliable_redis_backend.py
+++ b/tests/test_reliable_redis_backend.py
@@ -338,7 +338,7 @@ class ReliableRedisDeduplicationTests(RedisCleanupMixin, unittest.TestCase):
 
         with unittest.mock.patch(
             'time.time',
-            side_effect=itertools.count(time.time(), 30),
+            side_effect=itertools.count(time.time(), 1),
         ), unittest.mock.patch(
             'time.sleep',
         ) as mock_sleep:

--- a/tests/test_reliable_redis_backend.py
+++ b/tests/test_reliable_redis_backend.py
@@ -1,5 +1,7 @@
+import time
 import datetime
 import unittest
+import itertools
 import contextlib
 import unittest.mock
 from typing import Mapping, Iterator
@@ -324,3 +326,23 @@ class ReliableRedisDeduplicationTests(RedisCleanupMixin, unittest.TestCase):
             actual_job.as_dict(),
             "The queue job should be the original one",
         )
+
+    def test_pause(self):
+        QUEUE = 'the-queue'
+
+        self.enqueue_job(QUEUE)
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        five_minutes_time = now + datetime.timedelta(minutes=5)
+        self.backend.pause(QUEUE, five_minutes_time)
+
+        with unittest.mock.patch(
+            'time.time',
+            side_effect=itertools.count(time.time(), 30),
+        ), unittest.mock.patch(
+            'time.sleep',
+        ) as mock_sleep:
+            job = self.backend.dequeue(QUEUE, 2, 2)
+
+        self.assertIsNone(job, "Should have indicated no work was done")
+        self.assertTrue(mock_sleep.called)


### PR DESCRIPTION
This can be specified either as a duration or a time to un-pause, though either way the internal implementation relies on Redis' `SETEX` command. Both Redis backends are supported and use the same approach for compatibility.