### PR TITLE
Add support for bulk enqueueing tasks

### DIFF
--- a/django_lightweight_queue/backends/base.py
+++ b/django_lightweight_queue/backends/base.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, TypeVar, Optional
+from typing import Tuple, TypeVar, Optional, Collection
 
 from ..job import Job
 from ..types import QueueName, WorkerNumber
@@ -17,6 +17,16 @@ class BaseBackend(metaclass=ABCMeta):
     @abstractmethod
     def enqueue(self, job: Job, queue: QueueName) -> None:
         raise NotImplementedError()
+
+    def bulk_enqueue(self, jobs: Collection[Job], queue: QueueName) -> None:
+        """
+        Enqueue a number of tasks in one pass.
+
+        Backends are strongly encouraged to override this with a more efficient
+        implemenation if they can.
+        """
+        for job in jobs:
+            self.enqueue(job, queue)
 
     @abstractmethod
     def dequeue(self, queue: QueueName, worker_num: WorkerNumber, timeout: int) -> Optional[Job]:

--- a/django_lightweight_queue/task.py
+++ b/django_lightweight_queue/task.py
@@ -1,4 +1,16 @@
-from typing import Any, Generic, TypeVar, Callable, Optional
+from types import TracebackType
+from typing import (
+    Any,
+    cast,
+    Dict,
+    List,
+    Type,
+    Tuple,
+    Generic,
+    TypeVar,
+    Callable,
+    Optional,
+)
 
 from . import app_settings
 from .job import Job
@@ -83,6 +95,48 @@ class task:
         return TaskWrapper(fn, self.queue, self.timeout, self.sigkill_on_stop, self.atomic)
 
 
+class BulkEnqueueHelper(Generic[TCallable]):
+    def __init__(
+        self,
+        task_wrapper: 'TaskWrapper[TCallable]',
+        batch_size: int,
+        queue_override: Optional[QueueName],
+    ) -> None:
+        self._to_create: List[Job] = []
+        self._task_wrapper = task_wrapper
+        self.batch_size = batch_size
+        self.queue_override = queue_override
+
+    def __enter__(self) -> TCallable:
+        return cast(TCallable, self._create)
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.flush()
+
+    def _create(self, *args: Any, **kwargs: Any) -> None:
+        self._to_create.append(
+            self._task_wrapper._build_job(args, kwargs),
+        )
+        if len(self._to_create) >= self.batch_size:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self._to_create:
+            return
+
+        self._task_wrapper._enqueue_job_instances(
+            self._to_create,
+            queue_override=self.queue_override,
+        )
+
+        self._to_create = []
+
+
 class TaskWrapper(Generic[TCallable]):
     def __init__(
         self,
@@ -103,7 +157,7 @@ class TaskWrapper(Generic[TCallable]):
     def __repr__(self) -> str:
         return "<TaskWrapper: {}>".format(self.path)
 
-    def __call__(self, *args: Any, **kwargs: Any) -> None:
+    def _build_job(self, args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> Job:
         # Allow us to override the default values dynamically
         timeout = kwargs.pop('django_lightweight_queue_timeout', self.timeout)
         sigkill_on_stop = kwargs.pop(
@@ -111,10 +165,47 @@ class TaskWrapper(Generic[TCallable]):
             self.sigkill_on_stop,
         )
 
-        # Allow queue overrides, but you must ensure that this queue will exist
-        queue = kwargs.pop('django_lightweight_queue_queue', self.queue)
-
         job = Job(self.path, args, kwargs, timeout, sigkill_on_stop)
         job.validate()
 
+        return job
+
+    def _enqueue_job_instances(
+        self,
+        new_jobs: List[Job],
+        queue_override: Optional[QueueName],
+    ) -> None:
+        queue = queue_override if queue_override is not None else self.queue
+        get_backend(queue).bulk_enqueue(new_jobs, queue)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        job = self._build_job(args, kwargs)
+
+        # Allow queue overrides, but you must ensure that this queue will exist
+        queue = kwargs.pop('django_lightweight_queue_queue', self.queue)
+
         get_backend(queue).enqueue(job, queue)
+
+    def bulk_enqueue(
+        self,
+        batch_size: int = 1000,
+        queue_override: Optional[QueueName] = None,
+    ) -> BulkEnqueueHelper[TCallable]:
+        """
+        Enqueue jobs in bulk.
+
+        Use like:
+
+            with my_task.bulk_enqueue() as enqueue:
+                enqueue(the_ids=[42, 43])
+                enqueue(the_ids=[45, 46])
+
+        This is equivalent to:
+
+            my_task(the_ids=[42, 43])
+            my_task(the_ids=[45, 46])
+
+        The target queue for the whole batch may be overridden, however the
+        caller must ensure that the queue actually exists (i.e: has workers).
+        """
+        return BulkEnqueueHelper(self, batch_size, queue_override)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -95,7 +95,7 @@ class TaskTests(unittest.TestCase):
 
         with dummy_task.bulk_enqueue() as enqueue:
             enqueue(13)
-            enqueue(42)
+            enqueue(num=42)
 
         job = self.backend.dequeue(QUEUE, WorkerNumber(0), 5)
         # Plain assert to placate mypy
@@ -121,8 +121,8 @@ class TaskTests(unittest.TestCase):
         self.assertEqual(
             {
                 'path': 'tests.test_task.dummy_task',
-                'args': [42],
-                'kwargs': {},
+                'args': [],
+                'kwargs': {'num': 42},
                 'timeout': None,
                 'sigkill_on_stop': False,
                 'created_time': mock.ANY,

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,132 @@
+import unittest
+import contextlib
+from typing import Any, Mapping, Iterator
+from unittest import mock
+
+import fakeredis
+from django_lightweight_queue import task
+from django_lightweight_queue.types import QueueName, WorkerNumber
+from django_lightweight_queue.utils import get_path, get_backend
+from django_lightweight_queue.backends.redis import RedisBackend
+
+from . import settings
+
+QUEUE = QueueName('dummy-queue')
+
+
+@task(str(QUEUE))
+def dummy_task(num: int) -> None:
+    pass
+
+
+class TaskTests(unittest.TestCase):
+    longMessage = True
+    prefix = settings.LIGHTWEIGHT_QUEUE_REDIS_PREFIX
+
+    @contextlib.contextmanager
+    def mock_workers(self, workers: Mapping[str, int]) -> Iterator[None]:
+        with unittest.mock.patch(
+            'django_lightweight_queue.utils._accepting_implied_queues',
+            new=False,
+        ), unittest.mock.patch.dict(
+            'django_lightweight_queue.app_settings.WORKERS',
+            workers,
+        ):
+            yield
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        get_backend.cache_clear()
+
+        with mock.patch('redis.StrictRedis', fakeredis.FakeStrictRedis):
+            self.backend = RedisBackend()
+
+        # Mock get_backend. Unfortunately due to the nameing of the 'task'
+        # decorator class being the same as its containing module and it being
+        # exposed as the symbol at django_lightweight_queue.task, we cannot mock
+        # this in the normal way. Instead we mock get_path (which get_backend
+        # calls) and intercept the our dummy value.
+        def mocked_get_path(path: str) -> Any:
+            if path == 'test-backend':
+                return lambda: self.backend
+            return get_path(path)
+
+        patch = mock.patch(
+            'django_lightweight_queue.app_settings.BACKEND',
+            new='test-backend',
+        )
+        patch.start()
+        self.addCleanup(patch.stop)
+        patch = mock.patch(
+            'django_lightweight_queue.utils.get_path',
+            side_effect=mocked_get_path,
+        )
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        get_backend.cache_clear()
+
+    def test_enqueues_job(self) -> None:
+        self.assertEqual(0, self.backend.length(QUEUE))
+
+        dummy_task(42)
+
+        job = self.backend.dequeue(QUEUE, WorkerNumber(0), 5)
+        # Plain assert to placate mypy
+        assert job is not None, "Failed to get a job after enqueuing one"
+
+        self.assertEqual(
+            {
+                'path': 'tests.test_task.dummy_task',
+                'args': [42],
+                'kwargs': {},
+                'timeout': None,
+                'sigkill_on_stop': False,
+                'created_time': mock.ANY,
+            },
+            job.as_dict(),
+        )
+
+    def test_bulk_enqueues_jobs(self) -> None:
+        self.assertEqual(0, self.backend.length(QUEUE))
+
+        with dummy_task.bulk_enqueue() as enqueue:
+            enqueue(13)
+            enqueue(42)
+
+        job = self.backend.dequeue(QUEUE, WorkerNumber(0), 5)
+        # Plain assert to placate mypy
+        assert job is not None, "Failed to get a job after enqueuing one"
+
+        self.assertEqual(
+            {
+                'path': 'tests.test_task.dummy_task',
+                'args': [13],
+                'kwargs': {},
+                'timeout': None,
+                'sigkill_on_stop': False,
+                'created_time': mock.ANY,
+            },
+            job.as_dict(),
+            "First job",
+        )
+
+        job = self.backend.dequeue(QUEUE, WorkerNumber(0), 5)
+        # Plain assert to placate mypy
+        assert job is not None, "Failed to get a job after enqueuing one"
+
+        self.assertEqual(
+            {
+                'path': 'tests.test_task.dummy_task',
+                'args': [42],
+                'kwargs': {},
+                'timeout': None,
+                'sigkill_on_stop': False,
+                'created_time': mock.ANY,
+            },
+            job.as_dict(),
+            "Second job",
+        )


### PR DESCRIPTION
This aims to allow clients a more efficient mechanism than just looping over the tasks they're going to enqueue.

For the moment queue overrides are only allowed at a whole batch level, though I think there might be ways we could allow it on a per-job basis. That would involve doing some regrouping of the batching however and is unlikely to be easily efficient. For now therefore we push this up to the caller.