### PR TITLE
Update to isort v5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -156,19 +156,19 @@ pycodestyle = "*"
 
 [[package]]
 name = "flake8-isort"
-version = "3.0.1"
+version = "4.1.1"
 description = "flake8 plugin that integrates isort ."
 category = "dev"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-flake8 = ">=3.2.1,<4"
-isort = {version = ">=4.3.5,<5", extras = ["pyproject"]}
+flake8 = ">=3.2.1,<5"
+isort = ">=4.3.5,<6"
 testfixtures = ">=6.8.0,<7"
 
 [package.extras]
-test = ["pytest (>=4.0.2,<6)"]
+test = ["pytest-cov"]
 
 [[package]]
 name = "flake8-mutable"
@@ -225,20 +225,17 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [[package]]
 name = "isort"
-version = "4.3.21"
+version = "5.10.1"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-toml = {version = "*", optional = true, markers = "extra == \"pyproject\""}
+python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile = ["pipreqs", "requirementslib"]
-pyproject = ["toml"]
-requirements = ["pipreqs", "pip-api"]
-xdg_home = ["appdirs (>=1.4.0)"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "mccabe"
@@ -356,14 +353,6 @@ docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "
 test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
 name = "tqdm"
 version = "4.60.0"
 description = "Fast, Extensible Progress Meter"
@@ -410,8 +399,8 @@ redis = ["redis"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6"
-content-hash = "225614c9b143973d7f9de425fe30723c8b7156dcd998ee69cb79c92e5469b350"
+python-versions = ">=3.6.1,<4"
+content-hash = "cdde0753dbbf4b8a2e6005e232a2143eb01f6269b7b8e82df0a4388a0a6f8b07"
 
 [metadata.files]
 asgiref = [
@@ -462,8 +451,8 @@ flake8-debugger = [
     {file = "flake8-debugger-3.2.1.tar.gz", hash = "sha256:712d7c1ff69ddf3f0130e94cc88c2519e720760bce45e8c330bfdcb61ab4090d"},
 ]
 flake8-isort = [
-    {file = "flake8-isort-3.0.1.tar.gz", hash = "sha256:5d976da513cc390232ad5a9bb54aee8a092466a15f442d91dfc525834bee727a"},
-    {file = "flake8_isort-3.0.1-py2.py3-none-any.whl", hash = "sha256:df1dd6dd73f6a8b128c9c783356627231783cccc82c13c6dc343d1a5a491699b"},
+    {file = "flake8-isort-4.1.1.tar.gz", hash = "sha256:d814304ab70e6e58859bc5c3e221e2e6e71c958e7005239202fee19c24f82717"},
+    {file = "flake8_isort-4.1.1-py3-none-any.whl", hash = "sha256:c4e8b6dcb7be9b71a02e6e5d4196cefcef0f3447be51e82730fb336fff164949"},
 ]
 flake8-mutable = [
     {file = "flake8-mutable-1.2.0.tar.gz", hash = "sha256:ee9b77111b867d845177bbc289d87d541445ffcc6029a0c5c65865b42b18c6a6"},
@@ -482,8 +471,8 @@ importlib-metadata = [
     {file = "importlib_metadata-4.0.1.tar.gz", hash = "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581"},
 ]
 isort = [
-    {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
-    {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -544,10 +533,6 @@ sqlparse = [
 testfixtures = [
     {file = "testfixtures-6.17.1-py2.py3-none-any.whl", hash = "sha256:9ed31e83f59619e2fa17df053b241e16e0608f4580f7b5a9333a0c9bdcc99137"},
     {file = "testfixtures-6.17.1.tar.gz", hash = "sha256:5ec3a0dd6f71cc4c304fbc024a10cc293d3e0b852c868014b9f233203e149bda"},
-]
-toml = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tqdm = [
     {file = "tqdm-4.60.0-py2.py3-none-any.whl", hash = "sha256:daec693491c52e9498632dfbe9ccfc4882a557f5fa08982db1b4d3adbe0887c3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6"
+python = ">=3.6.1,<4"
 django = ">=2.2"
 daemonize = "~=2.5.0"
 prometheus-client = "~=0.7"
@@ -31,7 +31,7 @@ fakeredis = "^1.1.0"
 
 # Linting tools
 flake8 = "^3.8.0"
-isort = "^4.3.21"
+isort = "^5.10"
 mypy = "^0.780"
 
 # Flake 8 plugins
@@ -41,7 +41,7 @@ flake8-coding = "^1.3.2"
 flake8-commas = "^2.0.0"
 flake8-comprehensions = "^3.2.2"
 flake8-debugger = "^3.2.1"
-flake8-isort = "^3.0.0"
+flake8-isort = "^4.0.0"
 flake8-mutable = "^1.2.0"
 flake8-pep3101 = "^1.3.0"
 flake8-tidy-imports = "^4.1.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,6 @@ atomic = True
 known_django = django
 default_section = THIRDPARTY
 sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
-not_skip =
-    __init__.py,
 
 
 [mypy]

--- a/tests/test_reliable_redis_backend.py
+++ b/tests/test_reliable_redis_backend.py
@@ -5,6 +5,7 @@ import unittest.mock
 from typing import Any, Dict, Tuple, Mapping, Iterator, Optional
 
 import fakeredis
+
 from django_lightweight_queue.job import Job
 from django_lightweight_queue.types import QueueName
 from django_lightweight_queue.backends.reliable_redis import (

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -4,6 +4,7 @@ from typing import Any, Mapping, Iterator
 from unittest import mock
 
 import fakeredis
+
 from django_lightweight_queue import task
 from django_lightweight_queue.types import QueueName, WorkerNumber
 from django_lightweight_queue.utils import get_path, get_backend


### PR DESCRIPTION
This requires that we bump the minimum Python to 3.6.1, but that's likely fine given how old 3.6 is.