### PR TITLE
Modernise cron configuration import mechanics

### DIFF
--- a/django_lightweight_queue/cron_scheduler.py
+++ b/django_lightweight_queue/cron_scheduler.py
@@ -3,7 +3,7 @@ import time
 import datetime
 import importlib
 import threading
-from typing import Any, cast, Dict, List, Tuple, Callable, Optional, Sequence
+from typing import Any, Dict, List, Tuple, Callable, Optional, Sequence
 
 from typing_extensions import TypedDict
 
@@ -144,7 +144,8 @@ def get_cron_config() -> Sequence[CronConfig]:
                 # No module, move on.
                 continue
 
-        for row in cast(List[CronConfig], mod.CONFIG):
+        app_cron_config: List[CronConfig] = mod.CONFIG  # type: ignore[attr-defined]
+        for row in app_cron_config:
             row['min_matcher'] = get_matcher(0, 59, row.get('minutes'))
             row['hour_matcher'] = get_matcher(0, 23, row.get('hours'))
             row['day_matcher'] = get_matcher(1, 7, row.get('days', '*'))


### PR DESCRIPTION
### Summary

As far as I can tell this is functionally equivalent to the previous approach, however uses a mixture of supported Python and Django import utils rather than relying on `__import__` (which is discouraged) and the deprecated `imp` module.

This resolves deprecation warnings as well as some resource warnings that originated from the previous `imp.find_module` call.

### Testing

I've manually checked that
- the results of `queue_configurations` don't change (using our main codebase as the test case)
- that errors in the imported modules are similar (the stack trace changes slightly, gaining some `importlib` related layers)
