### PR TITLE
Don't export default_app_config above Django 3.2

### DIFF
--- a/django_lightweight_queue/__init__.py
+++ b/django_lightweight_queue/__init__.py
@@ -1,7 +1,10 @@
+import django
+
 from .task import task, TaskWrapper
 from .utils import contribute_implied_queue_name
 
-default_app_config = 'django_lightweight_queue.apps.DjangoLightweightQueueConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'django_lightweight_queue.apps.DjangoLightweightQueueConfig'
 
 __all__ = (
     'task',


### PR DESCRIPTION
It's deprecated from 3.2 onwards and planned for removal in 4.1.