### PR TITLE
Add missing dependency and retool settings for modern Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ backends are great candidates for community contributions.
 
 ## Basic Usage
 
+Start by adding `django_lightweight_queue` to your `INSTALLED_APPS`:
+
+```python
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    ...,
+    "django_lightweight_queue",
+]
+```
+
+After that, define your task in any file you want:
+
 ```python
 import time
 from django_lightweight_queue import task
@@ -67,12 +80,12 @@ present in the specified file are inherited from the global configuration.
 
 There are four built-in backends:
 
-| Backend        | Type        | Description                                                                                                                                                                       |
-| -------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Synchronous    | Development | Executes the task inline, without any actual queuing.                                                                                                                             |
-| Redis          | Production  | Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.                                                                                               |
-| Reliable Redis | Production  | Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.                      |
-| Debug Web      | Debugging   | Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks. |
+| Backend        | Import Location                                                       | Type        | Description                                                                                                                                                                       |
+| -------------- |:----------------------------------------------------------------------| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Synchronous    | django_lightweight_queue.backends.synchronous.SynchronousBackend      | Development | Executes the task inline, without any actual queuing.                                                                                                                             |
+| Redis          | django_lightweight_queue.backends.redis.RedisBackend                  | Production  | Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.                                                                                               |
+| Reliable Redis | django_lightweight_queue.backends.reliable_redis.ReliableRedisBackend | Production  | Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.                      |
+| Debug Web      | django_lightweight_queue.backends.debug_web.DebugWebBackend           | Debugging   | Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks. |
 
 [redis]: https://redis.io/
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ Executes tasks at-least-once using [Redis][redis] for storage of the enqueued ta
 
 Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks.
 
+Use this to append the appropriate URLs to the bottom of your root `urls.py`:
+
+```python
+from django.conf import settings
+from django.urls import path, include
+
+urlpatterns = [
+    ...
+]
+
+if "debug_web" in settings.LIGHTWEIGHT_QUEUE_BACKEND:
+    from django_lightweight_queue import urls as dlq_urls
+    urlpatterns += [path("", include(dlq_urls))]
+```
+
 This backend may require an extra setting if your debug site is not on localhost:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -80,12 +80,36 @@ present in the specified file are inherited from the global configuration.
 
 There are four built-in backends:
 
-| Backend        | Import Location                                                       | Type        | Description                                                                                                                                                                       |
-| -------------- |:----------------------------------------------------------------------| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Synchronous    | django_lightweight_queue.backends.synchronous.SynchronousBackend      | Development | Executes the task inline, without any actual queuing.                                                                                                                             |
-| Redis          | django_lightweight_queue.backends.redis.RedisBackend                  | Production  | Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.                                                                                               |
-| Reliable Redis | django_lightweight_queue.backends.reliable_redis.ReliableRedisBackend | Production  | Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.                      |
-| Debug Web      | django_lightweight_queue.backends.debug_web.DebugWebBackend           | Debugging   | Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks. |
+### Synchronous (Development backend)
+
+`django_lightweight_queue.backends.synchronous.SynchronousBackend`
+
+Executes the task inline, without any actual queuing.
+
+### Redis (Production backend)
+
+`django_lightweight_queue.backends.redis.RedisBackend`
+
+Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.
+
+### Reliable Redis (Production backend)
+
+`django_lightweight_queue.backends.reliable_redis.ReliableRedisBackend`
+
+Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.
+
+### Debug Web (Debug backend)
+
+`django_lightweight_queue.backends.debug_web.DebugWebBackend`
+
+Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks.
+
+This backend may require an extra setting if your debug site is not on localhost:
+
+```python
+# defaults to http://localhost:8000
+LIGHTWEIGHT_QUEUE_SITE_URL = "http://example.com:8000"
+```
 
 [redis]: https://redis.io/
 

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -185,6 +185,4 @@ class Settings():
         self._site_url = value
 
 
-
-
 settings = Settings()

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -177,7 +177,7 @@ class Settings():
     @property
     def SITE_URL(self):
         if not self._site_url:
-            self._site_url = self._get('SITE_URL', True)
+            self._site_url = self._get('SITE_URL', "http://localhost:8000")
         return self._site_url  # type: bool
 
     @SITE_URL.setter

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -15,6 +15,7 @@ class Settings():
 
     # adjustable values at runtime
     _backend = None
+    _redis_password = None
 
     @property
     def WORKERS(self):

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -14,12 +14,29 @@ class Settings():
         return getattr(django_settings, attr_name, default)
 
     # adjustable values at runtime
+    _workers = None
     _backend = None
+    _logger_factory = None
+    _backend_overrides = None
+    _middleware = None
+    _ignore_apps = None
+    _redis_host = None
+    _redis_port = None
     _redis_password = None
+    _redis_prefix = None
+    _enable_prometheus = None
+    _prometheus_start_port = None
+    _atomic_jobs = None
 
     @property
     def WORKERS(self):
-        return self._get('WORKERS', {})
+        if not self._workers:
+            self._workers = self._get('WORKERS', {})
+        return self._workers
+
+    @WORKERS.setter
+    def WORKERS(self, value):
+        self._workers = value
 
     @property
     def BACKEND(self):
@@ -36,21 +53,39 @@ class Settings():
 
     @property
     def LOGGER_FACTORY(self):
-        return self._get(
-            'LOGGER_FACTORY',
-            'logging.getLogger',
-        )  # type: Union[str, Callable[[str], Logger]]
+        if not self._logger_factory:
+            self._logger_factory = self._get(
+                'LOGGER_FACTORY',
+                'logging.getLogger',
+            )
+        return self._logger_factory  # type: Union[str, Callable[[str], Logger]]
+
+    @LOGGER_FACTORY.setter
+    def LOGGER_FACTORY(self, value):
+        self._logger_factory = value
 
     @property
     def BACKEND_OVERRIDES(self):
         # Allow per-queue overrides of the backend.
-        return self._get('BACKEND_OVERRIDES', {})  # type: Mapping[QueueName, str]
+        if not self._backend_overrides:
+            self._backend_overrides = self._get('BACKEND_OVERRIDES', {})
+        return self._backend_overrides  # type: Mapping[QueueName, str]
+
+    @BACKEND_OVERRIDES.setter
+    def BACKEND_OVERRIDES(self, value):
+        self._backend_overrides = value
 
     @property
     def MIDDLEWARE(self):
-        return self._get('MIDDLEWARE', (
-            'django_lightweight_queue.middleware.logging.LoggingMiddleware',
-        ))  # type: Sequence[str]
+        if not self._middleware:
+            self._middleware = self._get('MIDDLEWARE', (
+                'django_lightweight_queue.middleware.logging.LoggingMiddleware',
+            ))
+        return self._middleware  # type: Sequence[str]
+
+    @MIDDLEWARE.setter
+    def MIDDLEWARE(self, value):
+        self._middleware = value
 
     @property
     def IGNORE_APPS(self):
@@ -59,36 +94,84 @@ class Settings():
         # have a file called `tasks.py` within an app, but don't want
         # django-lightweight-queue to import that file.
         # Note: this _doesn't_ prevent tasks being registered from these apps.
-        return self._get('IGNORE_APPS', ())  # type: Sequence[str]
+        if not self._ignore_apps:
+            self._ignore_apps = self._get('IGNORE_APPS', ())
+        return self._ignore_apps  # type: Sequence[str]
+
+    @IGNORE_APPS.setter
+    def IGNORE_APPS(self, value):
+        self._ignore_apps = value
 
     @property
     def REDIS_HOST(self):
-        return self._get('REDIS_HOST', '127.0.0.1')  # type: str
+        if not self._redis_host:
+            self._redis_host = self._get('REDIS_HOST', '127.0.0.1')
+        return self._redis_host  # type: str
+
+    @REDIS_HOST.setter
+    def REDIS_HOST(self, value):
+        self._redis_host = value
 
     @property
     def REDIS_PORT(self):
-        return self._get('REDIS_PORT', 6379)  # type: int
+        if not self._redis_port:
+            self._redis_port = self._get('REDIS_PORT', 6379)
+        return self._redis_port  # type: int
+
+    @REDIS_PORT.setter
+    def REDIS_PORT(self, value):
+        self._redis_port = value
 
     @property
     def REDIS_PASSWORD(self):
-        return self._get('REDIS_PASSWORD', None)  # type: Optional[str]
+        if not self._redis_password:
+            self._redis_password = self._get('REDIS_PASSWORD', None)
+        return self._redis_password  # type: Optional[str]
+
+    @REDIS_PASSWORD.setter
+    def REDIS_PASSWORD(self, value):
+        self._redis_password = value
 
     @property
     def REDIS_PREFIX(self):
-        return self._get('REDIS_PREFIX', '')  # type: str
+        if not self._redis_prefix:
+            self._redis_prefix = self._get('REDIS_PREFIX', '')
+        return self._redis_prefix  # type: str
+
+    @REDIS_PREFIX.setter
+    def REDIS_PREFIX(self, value):
+        self._redis_prefix = value
 
     @property
     def ENABLE_PROMETHEUS(self):
-        return self._get('ENABLE_PROMETHEUS', False)  # type: bool
+        if not self._enable_prometheus:
+            self._enable_prometheus = self._get('ENABLE_PROMETHEUS', False)
+        return self._enable_prometheus  # type: bool
+
+    @ENABLE_PROMETHEUS.setter
+    def ENABLE_PROMETHEUS(self, value):
+        self._enable_prometheus = value
 
     @property
     def PROMETHEUS_START_PORT(self):
         # Workers will export metrics on this port, and ports following it
-        return self._get('PROMETHEUS_START_PORT', 9300)  # type: int
+        if not self._prometheus_start_port:
+            self._prometheus_start_port = self._get('PROMETHEUS_START_PORT', 9300)
+        return self._prometheus_start_port  # type: int
+
+    @PROMETHEUS_START_PORT.setter
+    def PROMETHEUS_START_PORT(self, value):
+        self._prometheus_start_port = value
 
     @property
     def ATOMIC_JOBS(self):
-        return self._get('ATOMIC_JOBS', True)  # type: bool
+        if not self._atomic_jobs:
+            self._atomic_jobs = self._get('ATOMIC_JOBS', True)
+        return self._atomic_jobs  # type: bool
+
+    @ATOMIC_JOBS.setter
+    def ATOMIC_JOBS(self, value):
+        self._atomic_jobs = value
 
 
 settings = Settings()

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -27,6 +27,7 @@ class Settings():
     _enable_prometheus = None
     _prometheus_start_port = None
     _atomic_jobs = None
+    _site_url = None
 
     @property
     def WORKERS(self):
@@ -172,6 +173,18 @@ class Settings():
     @ATOMIC_JOBS.setter
     def ATOMIC_JOBS(self, value):
         self._atomic_jobs = value
+
+    @property
+    def SITE_URL(self):
+        if not self._site_url:
+            self._site_url = self._get('SITE_URL', True)
+        return self._site_url  # type: bool
+
+    @SITE_URL.setter
+    def SITE_URL(self, value):
+        self._site_url = value
+
+
 
 
 settings = Settings()

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -1,6 +1,6 @@
-from typing import Dict, Union, Mapping, TypeVar, Callable, Optional, Sequence
+from typing import Union, Mapping, TypeVar, Callable, Optional, Sequence
 
-from django.conf import settings
+from django.conf import settings as django_settings
 
 from . import constants
 from .types import Logger, QueueName
@@ -8,45 +8,86 @@ from .types import Logger, QueueName
 T = TypeVar('T')
 
 
-def setting(suffix: str, default: T) -> T:
-    attr_name = '{}{}'.format(constants.SETTING_NAME_PREFIX, suffix)
-    return getattr(settings, attr_name, default)
+class Settings():
+    def _get(self, suffix: str, default: T) -> T:
+        attr_name = '{}{}'.format(constants.SETTING_NAME_PREFIX, suffix)
+        return getattr(django_settings, attr_name, default)
+
+    # adjustable values at runtime
+    _backend = None
+
+    @property
+    def WORKERS(self):
+        return self._get('WORKERS', {})
+
+    @property
+    def BACKEND(self):
+        if not self._backend:
+            self._backend = self._get(
+                'BACKEND',
+                'django_lightweight_queue.backends.synchronous.SynchronousBackend',
+            )
+        return self._backend  # type: str
+
+    @BACKEND.setter
+    def BACKEND(self, value):
+        self._backend = value
+
+    @property
+    def LOGGER_FACTORY(self):
+        return self._get(
+            'LOGGER_FACTORY',
+            'logging.getLogger',
+        )  # type: Union[str, Callable[[str], Logger]]
+
+    @property
+    def BACKEND_OVERRIDES(self):
+        # Allow per-queue overrides of the backend.
+        return self._get('BACKEND_OVERRIDES', {})  # type: Mapping[QueueName, str]
+
+    @property
+    def MIDDLEWARE(self):
+        return self._get('MIDDLEWARE', (
+            'django_lightweight_queue.middleware.logging.LoggingMiddleware',
+        ))  # type: Sequence[str]
+
+    @property
+    def IGNORE_APPS(self):
+        # Apps to ignore when looking for tasks. Apps must be specified as the dotted
+        # name used in `INSTALLED_APPS`. This is expected to be useful when you need to
+        # have a file called `tasks.py` within an app, but don't want
+        # django-lightweight-queue to import that file.
+        # Note: this _doesn't_ prevent tasks being registered from these apps.
+        return self._get('IGNORE_APPS', ())  # type: Sequence[str]
+
+    @property
+    def REDIS_HOST(self):
+        return self._get('REDIS_HOST', '127.0.0.1')  # type: str
+
+    @property
+    def REDIS_PORT(self):
+        return self._get('REDIS_PORT', 6379)  # type: int
+
+    @property
+    def REDIS_PASSWORD(self):
+        return self._get('REDIS_PASSWORD', None)  # type: Optional[str]
+
+    @property
+    def REDIS_PREFIX(self):
+        return self._get('REDIS_PREFIX', '')  # type: str
+
+    @property
+    def ENABLE_PROMETHEUS(self):
+        return self._get('ENABLE_PROMETHEUS', False)  # type: bool
+
+    @property
+    def PROMETHEUS_START_PORT(self):
+        # Workers will export metrics on this port, and ports following it
+        return self._get('PROMETHEUS_START_PORT', 9300)  # type: int
+
+    @property
+    def ATOMIC_JOBS(self):
+        return self._get('ATOMIC_JOBS', True)  # type: bool
 
 
-WORKERS = setting('WORKERS', {})  # type: Dict[QueueName, int]
-BACKEND = setting(
-    'BACKEND',
-    'django_lightweight_queue.backends.synchronous.SynchronousBackend',
-)  # type: str
-
-LOGGER_FACTORY = setting(
-    'LOGGER_FACTORY',
-    'logging.getLogger',
-)  # type: Union[str, Callable[[str], Logger]]
-
-# Allow per-queue overrides of the backend.
-BACKEND_OVERRIDES = setting('BACKEND_OVERRIDES', {})  # type: Mapping[QueueName, str]
-
-MIDDLEWARE = setting('MIDDLEWARE', (
-    'django_lightweight_queue.middleware.logging.LoggingMiddleware',
-    'django_lightweight_queue.middleware.transaction.TransactionMiddleware',
-))  # type: Sequence[str]
-
-# Apps to ignore when looking for tasks. Apps must be specified as the dotted
-# name used in `INSTALLED_APPS`. This is expected to be useful when you need to
-# have a file called `tasks.py` within an app, but don't want
-# django-lightweight-queue to import that file.
-# Note: this _doesn't_ prevent tasks being registered from these apps.
-IGNORE_APPS = setting('IGNORE_APPS', ())  # type: Sequence[str]
-
-# Backend-specific settings
-REDIS_HOST = setting('REDIS_HOST', '127.0.0.1')  # type: str
-REDIS_PORT = setting('REDIS_PORT', 6379)  # type: int
-REDIS_PASSWORD = setting('REDIS_PASSWORD', None)  # type: Optional[str]
-REDIS_PREFIX = setting('REDIS_PREFIX', '')  # type: str
-
-ENABLE_PROMETHEUS = setting('ENABLE_PROMETHEUS', False)  # type: bool
-# Workers will export metrics on this port, and ports following it
-PROMETHEUS_START_PORT = setting('PROMETHEUS_START_PORT', 9300)  # type: int
-
-ATOMIC_JOBS = setting('ATOMIC_JOBS', True)  # type: bool
+settings = Settings()

--- a/django_lightweight_queue/backends/debug_web.py
+++ b/django_lightweight_queue/backends/debug_web.py
@@ -1,11 +1,11 @@
 import urllib.parse
 
-from django.conf import settings
 from django.shortcuts import reverse
 
 from ..job import Job
 from .base import BaseBackend
 from ..types import QueueName, WorkerNumber
+from ..app_settings import settings
 
 
 class DebugWebBackend(BaseBackend):

--- a/django_lightweight_queue/backends/debug_web.py
+++ b/django_lightweight_queue/backends/debug_web.py
@@ -20,7 +20,7 @@ class DebugWebBackend(BaseBackend):
     """
 
     def enqueue(self, job: Job, queue: QueueName) -> None:
-        path = reverse('django-lightweight-queue:debug-run')
+        path = reverse('django_lightweight_queue:debug-run')
         query_string = urllib.parse.urlencode({'job': job.to_json()})
         url = "{}{}?{}".format(settings.SITE_URL, path, query_string)
         print(url)

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -3,11 +3,11 @@ from typing import Optional, Collection
 
 import redis
 
-from .. import app_settings
 from ..job import Job
 from .base import BackendWithPauseResume
 from ..types import QueueName, WorkerNumber
 from ..utils import block_for_time
+from ..app_settings import settings
 
 
 class RedisBackend(BackendWithPauseResume):
@@ -17,9 +17,9 @@ class RedisBackend(BackendWithPauseResume):
 
     def __init__(self) -> None:
         self.client = redis.StrictRedis(
-            host=app_settings.REDIS_HOST,
-            port=app_settings.REDIS_PORT,
-            password=app_settings.REDIS_PASSWORD,
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            password=settings.REDIS_PASSWORD,
         )
 
     def enqueue(self, job: Job, queue: QueueName) -> None:
@@ -79,9 +79,9 @@ class RedisBackend(BackendWithPauseResume):
         return bool(self.client.exists(self._pause_key(queue)))
 
     def _key(self, queue: QueueName) -> str:
-        if app_settings.REDIS_PREFIX:
+        if settings.REDIS_PREFIX:
             return '{}:django_lightweight_queue:{}'.format(
-                app_settings.REDIS_PREFIX,
+                settings.REDIS_PREFIX,
                 queue,
             )
 

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -3,11 +3,11 @@ from typing import Dict, List, Tuple, TypeVar, Optional, Collection
 
 import redis
 
-from .. import app_settings
 from ..job import Job
 from .base import BackendWithDeduplicate, BackendWithPauseResume
 from ..types import QueueName, WorkerNumber
 from ..utils import block_for_time, get_worker_numbers
+from ..app_settings import settings
 from ..progress_logger import ProgressLogger, NULL_PROGRESS_LOGGER
 
 # Work around https://github.com/python/mypy/issues/9914. Name needs to match
@@ -39,9 +39,9 @@ class ReliableRedisBackend(BackendWithDeduplicate, BackendWithPauseResume):
 
     def __init__(self) -> None:
         self.client = redis.StrictRedis(
-            host=app_settings.REDIS_HOST,
-            port=app_settings.REDIS_PORT,
-            password=app_settings.REDIS_PASSWORD,
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            password=settings.REDIS_PASSWORD,
         )
 
     def startup(self, queue: QueueName) -> None:
@@ -245,9 +245,9 @@ class ReliableRedisBackend(BackendWithDeduplicate, BackendWithPauseResume):
         return self._prefix_key(key)
 
     def _prefix_key(self, key: str) -> str:
-        if app_settings.REDIS_PREFIX:
+        if settings.REDIS_PREFIX:
             return '{}:{}'.format(
-                app_settings.REDIS_PREFIX,
+                settings.REDIS_PREFIX,
                 key,
             )
 

--- a/django_lightweight_queue/exposition.py
+++ b/django_lightweight_queue/exposition.py
@@ -6,8 +6,8 @@ from http.server import HTTPServer
 
 from prometheus_client.exposition import MetricsHandler
 
-from . import app_settings
 from .types import QueueName, WorkerNumber
+from .app_settings import settings
 
 
 def get_config_response(
@@ -23,7 +23,7 @@ def get_config_response(
             "targets": [
                 "{}:{}".format(
                     gethostname(),
-                    app_settings.PROMETHEUS_START_PORT + index,
+                    settings.PROMETHEUS_START_PORT + index,
                 ),
             ],
             "labels": {
@@ -60,7 +60,7 @@ def metrics_http_server(
             super(MetricsServer, self).__init__(*args, **kwargs)
 
         def run(self):
-            httpd = HTTPServer(('0.0.0.0', app_settings.PROMETHEUS_START_PORT), RequestHandler)
+            httpd = HTTPServer(('0.0.0.0', settings.PROMETHEUS_START_PORT), RequestHandler)
             httpd.timeout = 2
 
             try:

--- a/django_lightweight_queue/management/commands/queue_configuration.py
+++ b/django_lightweight_queue/management/commands/queue_configuration.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
 
-from ... import app_settings
 from ...utils import get_backend, get_queue_counts, load_extra_config
+from ...app_settings import settings
 from ...cron_scheduler import get_cron_config
 
 
@@ -37,7 +37,7 @@ class Command(BaseCommand):
 
         print("")
         print("Middleware:")
-        for x in app_settings.MIDDLEWARE:
+        for x in settings.MIDDLEWARE:
             print(" * {}".format(x))
 
         print("")

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -4,10 +4,10 @@ import signal
 import subprocess
 from typing import Dict, Tuple, Callable, Optional
 
-from . import app_settings
 from .types import Logger, QueueName, WorkerNumber
 from .utils import get_backend, set_process_title
 from .exposition import metrics_http_server
+from .app_settings import settings
 from .machine_types import Machine
 from .cron_scheduler import (
     CronScheduler,
@@ -64,7 +64,7 @@ def runner(
         for x in machine.worker_names
     }  # type: Dict[Tuple[QueueName, WorkerNumber], Tuple[Optional[subprocess.Popen[bytes]], str]]
 
-    if app_settings.ENABLE_PROMETHEUS:
+    if settings.ENABLE_PROMETHEUS:
         metrics_server = metrics_http_server(machine.worker_names)
         metrics_server.start()
 
@@ -107,7 +107,7 @@ def runner(
                     queue,
                     str(worker_num),
                     '--prometheus-port',
-                    str(app_settings.PROMETHEUS_START_PORT + index),
+                    str(settings.PROMETHEUS_START_PORT + index),
                 ]
 
                 touch_filename = touch_filename_fn(queue)

--- a/django_lightweight_queue/task.py
+++ b/django_lightweight_queue/task.py
@@ -12,10 +12,10 @@ from typing import (
     Optional,
 )
 
-from . import app_settings
 from .job import Job
 from .types import QueueName
 from .utils import get_backend, contribute_implied_queue_name
+from .app_settings import settings
 
 TCallable = TypeVar('TCallable', bound=Callable[..., Any])
 
@@ -82,7 +82,7 @@ class task:
         """
 
         if atomic is None:
-            atomic = app_settings.ATOMIC_JOBS
+            atomic = settings.ATOMIC_JOBS
 
         self.queue = QueueName(queue)
         self.timeout = timeout

--- a/django_lightweight_queue/urls.py
+++ b/django_lightweight_queue/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 app_name = 'django_lightweight_queue'
 
 urlpatterns = (
-    url(r'^debug/django-lightweight-queue/debug-run$', views.debug_run, name='debug-run'),
+    re_path(r'^debug/django-lightweight-queue/debug-run$', views.debug_run, name='debug-run'),
 )

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -12,12 +12,12 @@ from prometheus_client import Summary, start_http_server
 
 from django.db import connections, transaction
 
-from . import app_settings
 from .types import QueueName, WorkerNumber
 from .utils import get_logger, get_backend, set_process_title
+from .app_settings import settings
 from .backends.base import BaseBackend
 
-if app_settings.ENABLE_PROMETHEUS:
+if settings.ENABLE_PROMETHEUS:
     job_duration = Summary(
         'item_processed_seconds',
         "Item processing time",
@@ -54,7 +54,7 @@ class Worker:
         self.name = '{}/{}'.format(queue, worker_num)
 
     def run(self) -> None:
-        if app_settings.ENABLE_PROMETHEUS and self.prometheus_port is not None:
+        if settings.ENABLE_PROMETHEUS and self.prometheus_port is not None:
             self.log(logging.INFO, "Exporting metrics on port {}".format(self.prometheus_port))
             start_http_server(self.prometheus_port)
 
@@ -88,7 +88,7 @@ class Worker:
                 item_processed = self.process(backend)
                 post_process_time = time.time()
 
-                if app_settings.ENABLE_PROMETHEUS:
+                if settings.ENABLE_PROMETHEUS:
                     job_duration.labels(self.queue).observe(
                         post_process_time - pre_process_time,
                     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,17 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
 
 [[package]]
+name = "async-timeout"
+version = "4.0.2"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.5", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "attrs"
 version = "21.4.0"
 description = "Classes Without Boilerplate"
@@ -28,7 +39,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = true
@@ -75,7 +86,7 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "fakeredis"
-version = "1.7.1"
+version = "1.7.4"
 description = "Fake implementation of redis API for testing purposes."
 category = "dev"
 optional = false
@@ -83,7 +94,7 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 packaging = "*"
-redis = "<4.2.0"
+redis = "<=4.2.2"
 six = ">=1.12"
 sortedcontainers = "*"
 
@@ -236,11 +247,11 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "freezegun"
-version = "1.1.0"
+version = "1.2.1"
 description = "Let your Python tests travel through time"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 python-dateutil = ">=2.7"
@@ -260,6 +271,21 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "importlib-resources"
+version = "5.4.0"
+description = "Read resources from Python packages"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "isort"
@@ -322,7 +348,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "prometheus-client"
-version = "0.13.1"
+version = "0.14.1"
 description = "Python client for the Prometheus monitoring system."
 category = "main"
 optional = false
@@ -371,7 +397,7 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2021.3"
+version = "2022.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -379,16 +405,18 @@ python-versions = "*"
 
 [[package]]
 name = "redis"
-version = "4.1.4"
+version = "4.2.2"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
+async-timeout = ">=4.0.2"
 deprecated = ">=1.2.3"
 importlib-metadata = {version = ">=1.0", markers = "python_version < \"3.8\""}
 packaging = ">=20.4"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 hiredis = ["hiredis (>=1.0.0)"]
@@ -420,7 +448,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "testfixtures"
-version = "6.18.3"
+version = "6.18.5"
 description = "A collection of helpers and mock objects for unit tests and doc tests."
 category = "dev"
 optional = false
@@ -441,7 +469,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tqdm"
-version = "4.62.3"
+version = "4.64.0"
 description = "Fast, Extensible Progress Meter"
 category = "main"
 optional = true
@@ -449,10 +477,12 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "wheel"]
 notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
@@ -465,7 +495,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-freezegun"
-version = "1.1.6"
+version = "1.1.10"
 description = "Typing stubs for freezegun"
 category = "dev"
 optional = false
@@ -473,7 +503,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-redis"
-version = "4.1.16"
+version = "4.2.8"
 description = "Typing stubs for redis"
 category = "dev"
 optional = false
@@ -489,7 +519,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "wrapt"
-version = "1.13.3"
+version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
 category = "main"
 optional = false
@@ -514,20 +544,24 @@ redis = ["redis"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<4"
-content-hash = "346278f0990101fa1b95b98e44b910ec82017eb3a595afa05537f222a45af68b"
+content-hash = "f5e5c86ef7464dc0f73f3bd0833b51cf56090f62443ba9137fff531fd16e31a0"
 
 [metadata.files]
 asgiref = [
     {file = "asgiref-3.4.1-py3-none-any.whl", hash = "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"},
     {file = "asgiref-3.4.1.tar.gz", hash = "sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9"},
 ]
+async-timeout = [
+    {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
+    {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
+]
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 daemonize = [
     {file = "daemonize-2.5.0-py2.py3-none-any.whl", hash = "sha256:9b6b91311a9d934ff3f5f766666635ca280d3de8e7137e4cd7d3f052543b989f"},
@@ -542,8 +576,8 @@ django = [
     {file = "Django-3.2.13.tar.gz", hash = "sha256:6d93497a0a9bf6ba0e0b1a29cccdc40efbfc76297255b1309b3a884a688ec4b6"},
 ]
 fakeredis = [
-    {file = "fakeredis-1.7.1-py3-none-any.whl", hash = "sha256:be3668e50f6b57d5fc4abfd27f9f655bed07a2c5aecfc8b15d0aad59f997c1ba"},
-    {file = "fakeredis-1.7.1.tar.gz", hash = "sha256:7c2c4ba1b42e0a75337c54b777bf0671056b4569650e3ff927e4b9b385afc8ec"},
+    {file = "fakeredis-1.7.4-py3-none-any.whl", hash = "sha256:cc033ebf9af9f42bba6aa538a3e1a9f1732686b8b7e9ef50c7a44955bbc2aff8"},
+    {file = "fakeredis-1.7.4.tar.gz", hash = "sha256:69697ffeeb09939073605eeac97f524bccabae04265757a575c7fc923087aa65"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -590,12 +624,16 @@ flake8-tidy-imports = [
     {file = "flake8_tidy_imports-4.5.0-py3-none-any.whl", hash = "sha256:87eed94ae6a2fda6a5918d109746feadf1311e0eb8274ab7a7920f6db00a41c9"},
 ]
 freezegun = [
-    {file = "freezegun-1.1.0-py2.py3-none-any.whl", hash = "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"},
-    {file = "freezegun-1.1.0.tar.gz", hash = "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3"},
+    {file = "freezegun-1.2.1-py3-none-any.whl", hash = "sha256:15103a67dfa868ad809a8f508146e396be2995172d25f927e48ce51c0bf5cb09"},
+    {file = "freezegun-1.2.1.tar.gz", hash = "sha256:b4c64efb275e6bc68dc6e771b17ffe0ff0f90b81a2a5189043550b6519926ba4"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
     {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
+]
+importlib-resources = [
+    {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
+    {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
@@ -639,8 +677,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 prometheus-client = [
-    {file = "prometheus_client-0.13.1-py3-none-any.whl", hash = "sha256:357a447fd2359b0a1d2e9b311a0c5778c330cfbe186d880ad5a6b39884652316"},
-    {file = "prometheus_client-0.13.1.tar.gz", hash = "sha256:ada41b891b79fca5638bd5cfe149efa86512eaa55987893becd2c6d8d0a5dfc5"},
+    {file = "prometheus_client-0.14.1-py3-none-any.whl", hash = "sha256:522fded625282822a89e2773452f42df14b5a8e84a86433e3f8a189c1d54dc01"},
+    {file = "prometheus_client-0.14.1.tar.gz", hash = "sha256:5459c427624961076277fdc6dc50540e2bacb98eebde99886e59ec55ed92093a"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
@@ -659,12 +697,12 @@ python-dateutil = [
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
-    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
-    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
+    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
+    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
 ]
 redis = [
-    {file = "redis-4.1.4-py3-none-any.whl", hash = "sha256:04629f8e42be942c4f7d1812f2094568f04c612865ad19ad3ace3005da70631a"},
-    {file = "redis-4.1.4.tar.gz", hash = "sha256:1d9a0cdf89fdd93f84261733e24f55a7bbd413a9b219fdaf56e3e728ca9a2306"},
+    {file = "redis-4.2.2-py3-none-any.whl", hash = "sha256:4e95f4ec5f49e636efcf20061a5a9110c20852f607cfca6865c07aaa8a739ee2"},
+    {file = "redis-4.2.2.tar.gz", hash = "sha256:0107dc8e98a4f1d1d4aa00100e044287f77121a1e6d2085545c4b7fa94a7a27f"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -679,16 +717,16 @@ sqlparse = [
     {file = "sqlparse-0.4.2.tar.gz", hash = "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae"},
 ]
 testfixtures = [
-    {file = "testfixtures-6.18.3-py2.py3-none-any.whl", hash = "sha256:6ddb7f56a123e1a9339f130a200359092bd0a6455e31838d6c477e8729bb7763"},
-    {file = "testfixtures-6.18.3.tar.gz", hash = "sha256:2600100ae96ffd082334b378e355550fef8b4a529a6fa4c34f47130905c7426d"},
+    {file = "testfixtures-6.18.5-py2.py3-none-any.whl", hash = "sha256:7de200e24f50a4a5d6da7019fb1197aaf5abd475efb2ec2422fdcf2f2eb98c1d"},
+    {file = "testfixtures-6.18.5.tar.gz", hash = "sha256:02dae883f567f5b70fd3ad3c9eefb95912e78ac90be6c7444b5e2f46bf572c84"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tqdm = [
-    {file = "tqdm-4.62.3-py2.py3-none-any.whl", hash = "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c"},
-    {file = "tqdm-4.62.3.tar.gz", hash = "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"},
+    {file = "tqdm-4.64.0-py2.py3-none-any.whl", hash = "sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6"},
+    {file = "tqdm-4.64.0.tar.gz", hash = "sha256:40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -723,69 +761,82 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 types-freezegun = [
-    {file = "types-freezegun-1.1.6.tar.gz", hash = "sha256:5c70a4b7444b8c7dd2800e0063d6fe721ab11209399264fa0f77af253dd8b14f"},
-    {file = "types_freezegun-1.1.6-py3-none-any.whl", hash = "sha256:eaa4ccac7f4ff92762b6e5d34c3c4e41a7763b6d09a8595e0224ff1f24c9d4e1"},
+    {file = "types-freezegun-1.1.10.tar.gz", hash = "sha256:cb3a2d2eee950eacbaac0673ab50499823365ceb8c655babb1544a41446409ec"},
+    {file = "types_freezegun-1.1.10-py3-none-any.whl", hash = "sha256:fadebe72213e0674036153366205038e1f95c8ca96deb4ef9b71ddc15413543e"},
 ]
 types-redis = [
-    {file = "types-redis-4.1.16.tar.gz", hash = "sha256:a913521c1f008775fc3816813a5981f9da3b0dd3f3b2578b0a0464a84ac5f4d4"},
-    {file = "types_redis-4.1.16-py3-none-any.whl", hash = "sha256:a529fbae3b6c95e6790522d35a3065dc92ee29698c6b163ab573992b6144b41a"},
+    {file = "types-redis-4.2.8.tar.gz", hash = "sha256:2fe34d40bc7851db8752cda6210c4a8becd1bafd9adb5df189e11583770bf9a0"},
+    {file = "types_redis-4.2.8-py3-none-any.whl", hash = "sha256:ab0136dfd489dbd7e041dc77089dbc2239305f8e421bf92506db26b57ffaf1d3"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 wrapt = [
-    {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},
-    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489"},
-    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909"},
-    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229"},
-    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af"},
-    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de"},
-    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb"},
-    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80"},
-    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca"},
-    {file = "wrapt-1.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44"},
-    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056"},
-    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785"},
-    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096"},
-    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33"},
-    {file = "wrapt-1.13.3-cp310-cp310-win32.whl", hash = "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f"},
-    {file = "wrapt-1.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e"},
-    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d"},
-    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179"},
-    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3"},
-    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755"},
-    {file = "wrapt-1.13.3-cp35-cp35m-win32.whl", hash = "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851"},
-    {file = "wrapt-1.13.3-cp35-cp35m-win_amd64.whl", hash = "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13"},
-    {file = "wrapt-1.13.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918"},
-    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade"},
-    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc"},
-    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf"},
-    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125"},
-    {file = "wrapt-1.13.3-cp36-cp36m-win32.whl", hash = "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36"},
-    {file = "wrapt-1.13.3-cp36-cp36m-win_amd64.whl", hash = "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10"},
-    {file = "wrapt-1.13.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068"},
-    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709"},
-    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df"},
-    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2"},
-    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b"},
-    {file = "wrapt-1.13.3-cp37-cp37m-win32.whl", hash = "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829"},
-    {file = "wrapt-1.13.3-cp37-cp37m-win_amd64.whl", hash = "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"},
-    {file = "wrapt-1.13.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9"},
-    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554"},
-    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c"},
-    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b"},
-    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce"},
-    {file = "wrapt-1.13.3-cp38-cp38-win32.whl", hash = "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79"},
-    {file = "wrapt-1.13.3-cp38-cp38-win_amd64.whl", hash = "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb"},
-    {file = "wrapt-1.13.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb"},
-    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32"},
-    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7"},
-    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e"},
-    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640"},
-    {file = "wrapt-1.13.3-cp39-cp39-win32.whl", hash = "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374"},
-    {file = "wrapt-1.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb"},
-    {file = "wrapt-1.13.3.tar.gz", hash = "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185"},
+    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
+    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
+    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
+    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
+    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
+    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
+    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
+    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
+    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
+    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ daemonize = "~=2.5.0"
 prometheus-client = "~=0.7"
 redis = {version = "~=3.*", optional = true}
 tqdm = {version = "^4.54.1", optional = true}
+typing-extensions = "^4.1.1"
 
 [tool.poetry.extras]
 redis = ["redis"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-lightweight-queue"
-version = "4.5.0"
+version = "4.6.0"
 description = "Lightweight & modular queue and cron system for Django"
 authors = ["Thread Engineering <tech@thread.com>"]
 license = "BSD-3-Clause"

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -52,7 +52,7 @@ class PauseResumeTests(unittest.TestCase):
     # Can't use override_settings due to the copying of the settings values into
     # module values at startup.
     @mock.patch(
-        'django_lightweight_queue.app_settings.BACKEND',
+        'django_lightweight_queue.app_settings.Settings.BACKEND',
         new='django_lightweight_queue.backends.redis.RedisBackend',
     )
     def test_pause_resume(self) -> None:

--- a/tests/test_reliable_redis_backend.py
+++ b/tests/test_reliable_redis_backend.py
@@ -49,8 +49,8 @@ class ReliableRedisDeduplicationTests(RedisCleanupMixin, unittest.TestCase):
         with unittest.mock.patch(
             'django_lightweight_queue.utils._accepting_implied_queues',
             new=False,
-        ), unittest.mock.patch.dict(
-            'django_lightweight_queue.app_settings.WORKERS',
+        ), unittest.mock.patch(
+            'django_lightweight_queue.app_settings.Settings.WORKERS',
             workers,
         ):
             yield

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -30,7 +30,7 @@ class TaskTests(unittest.TestCase):
             'django_lightweight_queue.utils._accepting_implied_queues',
             new=False,
         ), unittest.mock.patch.dict(
-            'django_lightweight_queue.app_settings.WORKERS',
+            'django_lightweight_queue.app_settings.Settings.WORKERS',
             workers,
         ):
             yield
@@ -54,7 +54,7 @@ class TaskTests(unittest.TestCase):
             return get_path(path)
 
         patch = mock.patch(
-            'django_lightweight_queue.app_settings.BACKEND',
+            'django_lightweight_queue.app_settings.Settings.BACKEND',
             new='test-backend',
         )
         patch.start()


### PR DESCRIPTION
Hi, all!

Quick overview:

* add missing `typing_extensions` package
* update general dependencies
* convert settings system to modern design
* updates deprecations from Django 3 to allow running on Django 4
* various fixes for `debug_web`
* updated README

# The Big Kahuna

## Missing package & updates

I grabbed this package from PyPI for a project I'm working on, but on installing it throws an error because `typing_extensions` isn't installed. I found that's because `typing_extensions` is defined inside `poetry.lock`, but not actually listed as a dependency inside your `pyproject.toml` file -- so any time you install using the `poetry.lock` file it'll work fine, but any build created will be missing that dependency since only the information in `pyproject.toml` gets copied over to `setup.py`.

This PR adds `typing_extensions` as an explicit dependency so that it will appear in future builds and also just generally runs `poetry update`.

## Converting the Settings

This is what the bulk of this PR is concerned with; the existing system for settings assumes that everything is going to be in a single file with everything already defined. If you use a settings routing pattern like I do (where the root settings is just "if ENVIRONMENT == 'prod': from settings.base import *; if ENVIRONMENT == 'staging': from settings.staging import *") then it errors out on every key because nothing is technically available yet.

I rebuilt the settings to match the more flexible "get the setting when we actually need it" design pattern, taking inspiration from [django-cors-headers](https://github.com/adamchainz/django-cors-headers/blob/main/src/corsheaders/conf.py) and how that works. This one is slightly more complicated because `django-lightweight-queue` expects to be able to overwrite every value at runtime, so it retains that ability.

## Deprecations from Django 3

`from django.conf.urls import url` has been removed in Django 4, so I've substituted `re_path` which functions the same way and is valid in versions 2 through 4.

## Various fixes for Debug Web

Debug Web has two major issues: the first is that the reverse is looking for something that is not the app name (`django-lightweight-queue` vs `django_lightweight_queue`) and the second is that it expects a setting that is not standard and not listed anywhere else: `SITE_URL`. I've updated the reverse and added documentation about SITE_URL along with making it available as a custom setting for the package.

## Updated Readme

Added a few sections to the README relating to setting up `django_lightweight_queue` that were things I needed to know but were only discoverable by trawling through the source code. Hopefully it will help others who want to use this package.

---

I apologize for dropping an overly large PR on you over the weekend; I tried to be extremely careful in retaining existing expected functionality while still upgrading where necessary. I'm happy to update if you have requests -- as it stands, it passes flake8, isort, and the testing suite.

Cheers!