### PR TITLE
Fix django 4 regression

### DIFF
--- a/django_lightweight_queue/urls.py
+++ b/django_lightweight_queue/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 app_name = 'django_lightweight_queue'
 
 urlpatterns = (
-    url(r'^debug/django-lightweight-queue/debug-run$', views.debug_run, name='debug-run'),
+    re_path(r'^debug/django-lightweight-queue/debug-run$', views.debug_run, name='debug-run'),
 )

--- a/django_lightweight_queue/urls.py
+++ b/django_lightweight_queue/urls.py
@@ -1,9 +1,9 @@
-from django.urls import re_path
+from django.urls import path
 
 from . import views
 
 app_name = 'django_lightweight_queue'
 
 urlpatterns = (
-    re_path(r'^debug/django-lightweight-queue/debug-run$', views.debug_run, name='debug-run'),
+    path(r'debug/django-lightweight-queue/debug-run', views.debug_run, name='debug-run'),
 )


### PR DESCRIPTION
Expanding from https://github.com/thread/django-lightweight-queue/pull/61

Django 4.0 removes `url` entirely, so this PR replaces `url` with `re_path` which functions similarly.