### PR TITLE
Fixes for Debug Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ backends are great candidates for community contributions.
 
 ## Basic Usage
 
+Start by adding `django_lightweight_queue` to your `INSTALLED_APPS`:
+
+```python
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    ...,
+    "django_lightweight_queue",
+]
+```
+
+After that, define your task in any file you want:
+
 ```python
 import time
 from django_lightweight_queue import task
@@ -67,12 +80,12 @@ present in the specified file are inherited from the global configuration.
 
 There are four built-in backends:
 
-| Backend        | Type        | Description                                                                                                                                                                       |
-| -------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Synchronous    | Development | Executes the task inline, without any actual queuing.                                                                                                                             |
-| Redis          | Production  | Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.                                                                                               |
-| Reliable Redis | Production  | Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.                      |
-| Debug Web      | Debugging   | Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks. |
+| Backend        | Import Location                                                       | Type        | Description                                                                                                                                                                       |
+| -------------- |:----------------------------------------------------------------------| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Synchronous    | django_lightweight_queue.backends.synchronous.SynchronousBackend      | Development | Executes the task inline, without any actual queuing.                                                                                                                             |
+| Redis          | django_lightweight_queue.backends.redis.RedisBackend                  | Production  | Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.                                                                                               |
+| Reliable Redis | django_lightweight_queue.backends.reliable_redis.ReliableRedisBackend | Production  | Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.                      |
+| Debug Web      | django_lightweight_queue.backends.debug_web.DebugWebBackend           | Debugging   | Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks. |
 
 [redis]: https://redis.io/
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ Executes tasks at-least-once using [Redis][redis] for storage of the enqueued ta
 
 Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks.
 
+Use this to append the appropriate URLs to the bottom of your root `urls.py`:
+
+```python
+from django.conf import settings
+from django.urls import path, include
+
+urlpatterns = [
+    ...
+]
+
+if "debug_web" in settings.LIGHTWEIGHT_QUEUE_BACKEND:
+    from django_lightweight_queue import urls as dlq_urls
+    urlpatterns += [path("", include(dlq_urls))]
+```
+
 This backend may require an extra setting if your debug site is not on localhost:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -80,12 +80,36 @@ present in the specified file are inherited from the global configuration.
 
 There are four built-in backends:
 
-| Backend        | Import Location                                                       | Type        | Description                                                                                                                                                                       |
-| -------------- |:----------------------------------------------------------------------| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Synchronous    | django_lightweight_queue.backends.synchronous.SynchronousBackend      | Development | Executes the task inline, without any actual queuing.                                                                                                                             |
-| Redis          | django_lightweight_queue.backends.redis.RedisBackend                  | Production  | Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.                                                                                               |
-| Reliable Redis | django_lightweight_queue.backends.reliable_redis.ReliableRedisBackend | Production  | Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.                      |
-| Debug Web      | django_lightweight_queue.backends.debug_web.DebugWebBackend           | Debugging   | Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks. |
+### Synchronous (Development backend)
+
+`django_lightweight_queue.backends.synchronous.SynchronousBackend`
+
+Executes the task inline, without any actual queuing.
+
+### Redis (Production backend)
+
+`django_lightweight_queue.backends.redis.RedisBackend`
+
+Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.
+
+### Reliable Redis (Production backend)
+
+`django_lightweight_queue.backends.reliable_redis.ReliableRedisBackend`
+
+Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.
+
+### Debug Web (Debug backend)
+
+`django_lightweight_queue.backends.debug_web.DebugWebBackend`
+
+Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks.
+
+This backend may require an extra setting if your debug site is not on localhost:
+
+```python
+# defaults to http://localhost:8000
+LIGHTWEIGHT_QUEUE_SITE_URL = "http://example.com:8000"
+```
 
 [redis]: https://redis.io/
 

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -185,6 +185,4 @@ class Settings():
         self._site_url = value
 
 
-
-
 settings = Settings()

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -177,7 +177,7 @@ class Settings():
     @property
     def SITE_URL(self):
         if not self._site_url:
-            self._site_url = self._get('SITE_URL', True)
+            self._site_url = self._get('SITE_URL', "http://localhost:8000")
         return self._site_url  # type: bool
 
     @SITE_URL.setter

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -15,6 +15,7 @@ class Settings():
 
     # adjustable values at runtime
     _backend = None
+    _redis_password = None
 
     @property
     def WORKERS(self):

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -14,12 +14,29 @@ class Settings():
         return getattr(django_settings, attr_name, default)
 
     # adjustable values at runtime
+    _workers = None
     _backend = None
+    _logger_factory = None
+    _backend_overrides = None
+    _middleware = None
+    _ignore_apps = None
+    _redis_host = None
+    _redis_port = None
     _redis_password = None
+    _redis_prefix = None
+    _enable_prometheus = None
+    _prometheus_start_port = None
+    _atomic_jobs = None
 
     @property
     def WORKERS(self):
-        return self._get('WORKERS', {})
+        if not self._workers:
+            self._workers = self._get('WORKERS', {})
+        return self._workers
+
+    @WORKERS.setter
+    def WORKERS(self, value):
+        self._workers = value
 
     @property
     def BACKEND(self):
@@ -36,21 +53,39 @@ class Settings():
 
     @property
     def LOGGER_FACTORY(self):
-        return self._get(
-            'LOGGER_FACTORY',
-            'logging.getLogger',
-        )  # type: Union[str, Callable[[str], Logger]]
+        if not self._logger_factory:
+            self._logger_factory = self._get(
+                'LOGGER_FACTORY',
+                'logging.getLogger',
+            )
+        return self._logger_factory  # type: Union[str, Callable[[str], Logger]]
+
+    @LOGGER_FACTORY.setter
+    def LOGGER_FACTORY(self, value):
+        self._logger_factory = value
 
     @property
     def BACKEND_OVERRIDES(self):
         # Allow per-queue overrides of the backend.
-        return self._get('BACKEND_OVERRIDES', {})  # type: Mapping[QueueName, str]
+        if not self._backend_overrides:
+            self._backend_overrides = self._get('BACKEND_OVERRIDES', {})
+        return self._backend_overrides  # type: Mapping[QueueName, str]
+
+    @BACKEND_OVERRIDES.setter
+    def BACKEND_OVERRIDES(self, value):
+        self._backend_overrides = value
 
     @property
     def MIDDLEWARE(self):
-        return self._get('MIDDLEWARE', (
-            'django_lightweight_queue.middleware.logging.LoggingMiddleware',
-        ))  # type: Sequence[str]
+        if not self._middleware:
+            self._middleware = self._get('MIDDLEWARE', (
+                'django_lightweight_queue.middleware.logging.LoggingMiddleware',
+            ))
+        return self._middleware  # type: Sequence[str]
+
+    @MIDDLEWARE.setter
+    def MIDDLEWARE(self, value):
+        self._middleware = value
 
     @property
     def IGNORE_APPS(self):
@@ -59,36 +94,84 @@ class Settings():
         # have a file called `tasks.py` within an app, but don't want
         # django-lightweight-queue to import that file.
         # Note: this _doesn't_ prevent tasks being registered from these apps.
-        return self._get('IGNORE_APPS', ())  # type: Sequence[str]
+        if not self._ignore_apps:
+            self._ignore_apps = self._get('IGNORE_APPS', ())
+        return self._ignore_apps  # type: Sequence[str]
+
+    @IGNORE_APPS.setter
+    def IGNORE_APPS(self, value):
+        self._ignore_apps = value
 
     @property
     def REDIS_HOST(self):
-        return self._get('REDIS_HOST', '127.0.0.1')  # type: str
+        if not self._redis_host:
+            self._redis_host = self._get('REDIS_HOST', '127.0.0.1')
+        return self._redis_host  # type: str
+
+    @REDIS_HOST.setter
+    def REDIS_HOST(self, value):
+        self._redis_host = value
 
     @property
     def REDIS_PORT(self):
-        return self._get('REDIS_PORT', 6379)  # type: int
+        if not self._redis_port:
+            self._redis_port = self._get('REDIS_PORT', 6379)
+        return self._redis_port  # type: int
+
+    @REDIS_PORT.setter
+    def REDIS_PORT(self, value):
+        self._redis_port = value
 
     @property
     def REDIS_PASSWORD(self):
-        return self._get('REDIS_PASSWORD', None)  # type: Optional[str]
+        if not self._redis_password:
+            self._redis_password = self._get('REDIS_PASSWORD', None)
+        return self._redis_password  # type: Optional[str]
+
+    @REDIS_PASSWORD.setter
+    def REDIS_PASSWORD(self, value):
+        self._redis_password = value
 
     @property
     def REDIS_PREFIX(self):
-        return self._get('REDIS_PREFIX', '')  # type: str
+        if not self._redis_prefix:
+            self._redis_prefix = self._get('REDIS_PREFIX', '')
+        return self._redis_prefix  # type: str
+
+    @REDIS_PREFIX.setter
+    def REDIS_PREFIX(self, value):
+        self._redis_prefix = value
 
     @property
     def ENABLE_PROMETHEUS(self):
-        return self._get('ENABLE_PROMETHEUS', False)  # type: bool
+        if not self._enable_prometheus:
+            self._enable_prometheus = self._get('ENABLE_PROMETHEUS', False)
+        return self._enable_prometheus  # type: bool
+
+    @ENABLE_PROMETHEUS.setter
+    def ENABLE_PROMETHEUS(self, value):
+        self._enable_prometheus = value
 
     @property
     def PROMETHEUS_START_PORT(self):
         # Workers will export metrics on this port, and ports following it
-        return self._get('PROMETHEUS_START_PORT', 9300)  # type: int
+        if not self._prometheus_start_port:
+            self._prometheus_start_port = self._get('PROMETHEUS_START_PORT', 9300)
+        return self._prometheus_start_port  # type: int
+
+    @PROMETHEUS_START_PORT.setter
+    def PROMETHEUS_START_PORT(self, value):
+        self._prometheus_start_port = value
 
     @property
     def ATOMIC_JOBS(self):
-        return self._get('ATOMIC_JOBS', True)  # type: bool
+        if not self._atomic_jobs:
+            self._atomic_jobs = self._get('ATOMIC_JOBS', True)
+        return self._atomic_jobs  # type: bool
+
+    @ATOMIC_JOBS.setter
+    def ATOMIC_JOBS(self, value):
+        self._atomic_jobs = value
 
 
 settings = Settings()

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -27,6 +27,7 @@ class Settings():
     _enable_prometheus = None
     _prometheus_start_port = None
     _atomic_jobs = None
+    _site_url = None
 
     @property
     def WORKERS(self):
@@ -172,6 +173,18 @@ class Settings():
     @ATOMIC_JOBS.setter
     def ATOMIC_JOBS(self, value):
         self._atomic_jobs = value
+
+    @property
+    def SITE_URL(self):
+        if not self._site_url:
+            self._site_url = self._get('SITE_URL', True)
+        return self._site_url  # type: bool
+
+    @SITE_URL.setter
+    def SITE_URL(self, value):
+        self._site_url = value
+
+
 
 
 settings = Settings()

--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -1,6 +1,6 @@
-from typing import Dict, Union, Mapping, TypeVar, Callable, Optional, Sequence
+from typing import Union, Mapping, TypeVar, Callable, Optional, Sequence
 
-from django.conf import settings
+from django.conf import settings as django_settings
 
 from . import constants
 from .types import Logger, QueueName
@@ -8,45 +8,86 @@ from .types import Logger, QueueName
 T = TypeVar('T')
 
 
-def setting(suffix: str, default: T) -> T:
-    attr_name = '{}{}'.format(constants.SETTING_NAME_PREFIX, suffix)
-    return getattr(settings, attr_name, default)
+class Settings():
+    def _get(self, suffix: str, default: T) -> T:
+        attr_name = '{}{}'.format(constants.SETTING_NAME_PREFIX, suffix)
+        return getattr(django_settings, attr_name, default)
+
+    # adjustable values at runtime
+    _backend = None
+
+    @property
+    def WORKERS(self):
+        return self._get('WORKERS', {})
+
+    @property
+    def BACKEND(self):
+        if not self._backend:
+            self._backend = self._get(
+                'BACKEND',
+                'django_lightweight_queue.backends.synchronous.SynchronousBackend',
+            )
+        return self._backend  # type: str
+
+    @BACKEND.setter
+    def BACKEND(self, value):
+        self._backend = value
+
+    @property
+    def LOGGER_FACTORY(self):
+        return self._get(
+            'LOGGER_FACTORY',
+            'logging.getLogger',
+        )  # type: Union[str, Callable[[str], Logger]]
+
+    @property
+    def BACKEND_OVERRIDES(self):
+        # Allow per-queue overrides of the backend.
+        return self._get('BACKEND_OVERRIDES', {})  # type: Mapping[QueueName, str]
+
+    @property
+    def MIDDLEWARE(self):
+        return self._get('MIDDLEWARE', (
+            'django_lightweight_queue.middleware.logging.LoggingMiddleware',
+        ))  # type: Sequence[str]
+
+    @property
+    def IGNORE_APPS(self):
+        # Apps to ignore when looking for tasks. Apps must be specified as the dotted
+        # name used in `INSTALLED_APPS`. This is expected to be useful when you need to
+        # have a file called `tasks.py` within an app, but don't want
+        # django-lightweight-queue to import that file.
+        # Note: this _doesn't_ prevent tasks being registered from these apps.
+        return self._get('IGNORE_APPS', ())  # type: Sequence[str]
+
+    @property
+    def REDIS_HOST(self):
+        return self._get('REDIS_HOST', '127.0.0.1')  # type: str
+
+    @property
+    def REDIS_PORT(self):
+        return self._get('REDIS_PORT', 6379)  # type: int
+
+    @property
+    def REDIS_PASSWORD(self):
+        return self._get('REDIS_PASSWORD', None)  # type: Optional[str]
+
+    @property
+    def REDIS_PREFIX(self):
+        return self._get('REDIS_PREFIX', '')  # type: str
+
+    @property
+    def ENABLE_PROMETHEUS(self):
+        return self._get('ENABLE_PROMETHEUS', False)  # type: bool
+
+    @property
+    def PROMETHEUS_START_PORT(self):
+        # Workers will export metrics on this port, and ports following it
+        return self._get('PROMETHEUS_START_PORT', 9300)  # type: int
+
+    @property
+    def ATOMIC_JOBS(self):
+        return self._get('ATOMIC_JOBS', True)  # type: bool
 
 
-WORKERS = setting('WORKERS', {})  # type: Dict[QueueName, int]
-BACKEND = setting(
-    'BACKEND',
-    'django_lightweight_queue.backends.synchronous.SynchronousBackend',
-)  # type: str
-
-LOGGER_FACTORY = setting(
-    'LOGGER_FACTORY',
-    'logging.getLogger',
-)  # type: Union[str, Callable[[str], Logger]]
-
-# Allow per-queue overrides of the backend.
-BACKEND_OVERRIDES = setting('BACKEND_OVERRIDES', {})  # type: Mapping[QueueName, str]
-
-MIDDLEWARE = setting('MIDDLEWARE', (
-    'django_lightweight_queue.middleware.logging.LoggingMiddleware',
-    'django_lightweight_queue.middleware.transaction.TransactionMiddleware',
-))  # type: Sequence[str]
-
-# Apps to ignore when looking for tasks. Apps must be specified as the dotted
-# name used in `INSTALLED_APPS`. This is expected to be useful when you need to
-# have a file called `tasks.py` within an app, but don't want
-# django-lightweight-queue to import that file.
-# Note: this _doesn't_ prevent tasks being registered from these apps.
-IGNORE_APPS = setting('IGNORE_APPS', ())  # type: Sequence[str]
-
-# Backend-specific settings
-REDIS_HOST = setting('REDIS_HOST', '127.0.0.1')  # type: str
-REDIS_PORT = setting('REDIS_PORT', 6379)  # type: int
-REDIS_PASSWORD = setting('REDIS_PASSWORD', None)  # type: Optional[str]
-REDIS_PREFIX = setting('REDIS_PREFIX', '')  # type: str
-
-ENABLE_PROMETHEUS = setting('ENABLE_PROMETHEUS', False)  # type: bool
-# Workers will export metrics on this port, and ports following it
-PROMETHEUS_START_PORT = setting('PROMETHEUS_START_PORT', 9300)  # type: int
-
-ATOMIC_JOBS = setting('ATOMIC_JOBS', True)  # type: bool
+settings = Settings()

--- a/django_lightweight_queue/backends/debug_web.py
+++ b/django_lightweight_queue/backends/debug_web.py
@@ -1,11 +1,11 @@
 import urllib.parse
 
-from django.conf import settings
 from django.shortcuts import reverse
 
 from ..job import Job
 from .base import BaseBackend
 from ..types import QueueName, WorkerNumber
+from ..app_settings import settings
 
 
 class DebugWebBackend(BaseBackend):

--- a/django_lightweight_queue/backends/debug_web.py
+++ b/django_lightweight_queue/backends/debug_web.py
@@ -20,7 +20,7 @@ class DebugWebBackend(BaseBackend):
     """
 
     def enqueue(self, job: Job, queue: QueueName) -> None:
-        path = reverse('django-lightweight-queue:debug-run')
+        path = reverse('django_lightweight_queue:debug-run')
         query_string = urllib.parse.urlencode({'job': job.to_json()})
         url = "{}{}?{}".format(settings.SITE_URL, path, query_string)
         print(url)

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -3,11 +3,11 @@ from typing import Optional, Collection
 
 import redis
 
-from .. import app_settings
 from ..job import Job
 from .base import BackendWithPauseResume
 from ..types import QueueName, WorkerNumber
 from ..utils import block_for_time
+from ..app_settings import settings
 
 
 class RedisBackend(BackendWithPauseResume):
@@ -17,9 +17,9 @@ class RedisBackend(BackendWithPauseResume):
 
     def __init__(self) -> None:
         self.client = redis.StrictRedis(
-            host=app_settings.REDIS_HOST,
-            port=app_settings.REDIS_PORT,
-            password=app_settings.REDIS_PASSWORD,
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            password=settings.REDIS_PASSWORD,
         )
 
     def enqueue(self, job: Job, queue: QueueName) -> None:
@@ -79,9 +79,9 @@ class RedisBackend(BackendWithPauseResume):
         return bool(self.client.exists(self._pause_key(queue)))
 
     def _key(self, queue: QueueName) -> str:
-        if app_settings.REDIS_PREFIX:
+        if settings.REDIS_PREFIX:
             return '{}:django_lightweight_queue:{}'.format(
-                app_settings.REDIS_PREFIX,
+                settings.REDIS_PREFIX,
                 queue,
             )
 

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -3,11 +3,11 @@ from typing import Dict, List, Tuple, TypeVar, Optional, Collection
 
 import redis
 
-from .. import app_settings
 from ..job import Job
 from .base import BackendWithDeduplicate, BackendWithPauseResume
 from ..types import QueueName, WorkerNumber
 from ..utils import block_for_time, get_worker_numbers
+from ..app_settings import settings
 from ..progress_logger import ProgressLogger, NULL_PROGRESS_LOGGER
 
 # Work around https://github.com/python/mypy/issues/9914. Name needs to match
@@ -39,9 +39,9 @@ class ReliableRedisBackend(BackendWithDeduplicate, BackendWithPauseResume):
 
     def __init__(self) -> None:
         self.client = redis.StrictRedis(
-            host=app_settings.REDIS_HOST,
-            port=app_settings.REDIS_PORT,
-            password=app_settings.REDIS_PASSWORD,
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            password=settings.REDIS_PASSWORD,
         )
 
     def startup(self, queue: QueueName) -> None:
@@ -245,9 +245,9 @@ class ReliableRedisBackend(BackendWithDeduplicate, BackendWithPauseResume):
         return self._prefix_key(key)
 
     def _prefix_key(self, key: str) -> str:
-        if app_settings.REDIS_PREFIX:
+        if settings.REDIS_PREFIX:
             return '{}:{}'.format(
-                app_settings.REDIS_PREFIX,
+                settings.REDIS_PREFIX,
                 key,
             )
 

--- a/django_lightweight_queue/exposition.py
+++ b/django_lightweight_queue/exposition.py
@@ -6,8 +6,8 @@ from http.server import HTTPServer
 
 from prometheus_client.exposition import MetricsHandler
 
-from . import app_settings
 from .types import QueueName, WorkerNumber
+from .app_settings import settings
 
 
 def get_config_response(
@@ -23,7 +23,7 @@ def get_config_response(
             "targets": [
                 "{}:{}".format(
                     gethostname(),
-                    app_settings.PROMETHEUS_START_PORT + index,
+                    settings.PROMETHEUS_START_PORT + index,
                 ),
             ],
             "labels": {
@@ -60,7 +60,7 @@ def metrics_http_server(
             super(MetricsServer, self).__init__(*args, **kwargs)
 
         def run(self):
-            httpd = HTTPServer(('0.0.0.0', app_settings.PROMETHEUS_START_PORT), RequestHandler)
+            httpd = HTTPServer(('0.0.0.0', settings.PROMETHEUS_START_PORT), RequestHandler)
             httpd.timeout = 2
 
             try:

--- a/django_lightweight_queue/management/commands/queue_configuration.py
+++ b/django_lightweight_queue/management/commands/queue_configuration.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
 
-from ... import app_settings
 from ...utils import get_backend, get_queue_counts, load_extra_config
+from ...app_settings import settings
 from ...cron_scheduler import get_cron_config
 
 
@@ -37,7 +37,7 @@ class Command(BaseCommand):
 
         print("")
         print("Middleware:")
-        for x in app_settings.MIDDLEWARE:
+        for x in settings.MIDDLEWARE:
             print(" * {}".format(x))
 
         print("")

--- a/django_lightweight_queue/runner.py
+++ b/django_lightweight_queue/runner.py
@@ -4,10 +4,10 @@ import signal
 import subprocess
 from typing import Dict, Tuple, Callable, Optional
 
-from . import app_settings
 from .types import Logger, QueueName, WorkerNumber
 from .utils import get_backend, set_process_title
 from .exposition import metrics_http_server
+from .app_settings import settings
 from .machine_types import Machine
 from .cron_scheduler import (
     CronScheduler,
@@ -64,7 +64,7 @@ def runner(
         for x in machine.worker_names
     }  # type: Dict[Tuple[QueueName, WorkerNumber], Tuple[Optional[subprocess.Popen[bytes]], str]]
 
-    if app_settings.ENABLE_PROMETHEUS:
+    if settings.ENABLE_PROMETHEUS:
         metrics_server = metrics_http_server(machine.worker_names)
         metrics_server.start()
 
@@ -107,7 +107,7 @@ def runner(
                     queue,
                     str(worker_num),
                     '--prometheus-port',
-                    str(app_settings.PROMETHEUS_START_PORT + index),
+                    str(settings.PROMETHEUS_START_PORT + index),
                 ]
 
                 touch_filename = touch_filename_fn(queue)

--- a/django_lightweight_queue/task.py
+++ b/django_lightweight_queue/task.py
@@ -12,10 +12,10 @@ from typing import (
     Optional,
 )
 
-from . import app_settings
 from .job import Job
 from .types import QueueName
 from .utils import get_backend, contribute_implied_queue_name
+from .app_settings import settings
 
 TCallable = TypeVar('TCallable', bound=Callable[..., Any])
 
@@ -82,7 +82,7 @@ class task:
         """
 
         if atomic is None:
-            atomic = app_settings.ATOMIC_JOBS
+            atomic = settings.ATOMIC_JOBS
 
         self.queue = QueueName(queue)
         self.timeout = timeout

--- a/django_lightweight_queue/worker.py
+++ b/django_lightweight_queue/worker.py
@@ -12,12 +12,12 @@ from prometheus_client import Summary, start_http_server
 
 from django.db import connections, transaction
 
-from . import app_settings
 from .types import QueueName, WorkerNumber
 from .utils import get_logger, get_backend, set_process_title
+from .app_settings import settings
 from .backends.base import BaseBackend
 
-if app_settings.ENABLE_PROMETHEUS:
+if settings.ENABLE_PROMETHEUS:
     job_duration = Summary(
         'item_processed_seconds',
         "Item processing time",
@@ -54,7 +54,7 @@ class Worker:
         self.name = '{}/{}'.format(queue, worker_num)
 
     def run(self) -> None:
-        if app_settings.ENABLE_PROMETHEUS and self.prometheus_port is not None:
+        if settings.ENABLE_PROMETHEUS and self.prometheus_port is not None:
             self.log(logging.INFO, "Exporting metrics on port {}".format(self.prometheus_port))
             start_http_server(self.prometheus_port)
 
@@ -88,7 +88,7 @@ class Worker:
                 item_processed = self.process(backend)
                 post_process_time = time.time()
 
-                if app_settings.ENABLE_PROMETHEUS:
+                if settings.ENABLE_PROMETHEUS:
                     job_duration.labels(self.queue).observe(
                         post_process_time - pre_process_time,
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-lightweight-queue"
-version = "4.5.1"
+version = "4.6.0"
 description = "Lightweight & modular queue and cron system for Django"
 authors = ["Thread Engineering <tech@thread.com>"]
 license = "BSD-3-Clause"

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -52,7 +52,7 @@ class PauseResumeTests(unittest.TestCase):
     # Can't use override_settings due to the copying of the settings values into
     # module values at startup.
     @mock.patch(
-        'django_lightweight_queue.app_settings.BACKEND',
+        'django_lightweight_queue.app_settings.Settings.BACKEND',
         new='django_lightweight_queue.backends.redis.RedisBackend',
     )
     def test_pause_resume(self) -> None:

--- a/tests/test_reliable_redis_backend.py
+++ b/tests/test_reliable_redis_backend.py
@@ -49,8 +49,8 @@ class ReliableRedisDeduplicationTests(RedisCleanupMixin, unittest.TestCase):
         with unittest.mock.patch(
             'django_lightweight_queue.utils._accepting_implied_queues',
             new=False,
-        ), unittest.mock.patch.dict(
-            'django_lightweight_queue.app_settings.WORKERS',
+        ), unittest.mock.patch(
+            'django_lightweight_queue.app_settings.Settings.WORKERS',
             workers,
         ):
             yield

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -30,7 +30,7 @@ class TaskTests(unittest.TestCase):
             'django_lightweight_queue.utils._accepting_implied_queues',
             new=False,
         ), unittest.mock.patch.dict(
-            'django_lightweight_queue.app_settings.WORKERS',
+            'django_lightweight_queue.app_settings.Settings.WORKERS',
             workers,
         ):
             yield
@@ -54,7 +54,7 @@ class TaskTests(unittest.TestCase):
             return get_path(path)
 
         patch = mock.patch(
-            'django_lightweight_queue.app_settings.BACKEND',
+            'django_lightweight_queue.app_settings.Settings.BACKEND',
             new='test-backend',
         )
         patch.start()


### PR DESCRIPTION
Expanding from https://github.com/thread/django-lightweight-queue/pull/61

This is a stacked PR with https://github.com/thread/django-lightweight-queue/pull/62 and that one should be merged first.

This PR:

* updates the reverse URL to match the name of the app
* includes a setting for the non-standard `SITE_URL` config item
* updates the readme with information relating to this new setting

⚠️ BREAKING CHANGES: ⚠️ 

`SITE_URL` is now expected as `LIGHTWEIGHT_QUEUE_SITE_URL` to match with the rest of the settings.