### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,15 @@ urlpatterns = [
     ...
 ]
 
-if "debug_web" in settings.LIGHTWEIGHT_QUEUE_BACKEND:
-    from django_lightweight_queue import urls as dlq_urls
-    urlpatterns += [path("", include(dlq_urls))]
+if settings.DEBUG:
+    urlpatterns += [
+        path(
+            "",
+            include(
+                "django_lightweight_queue.urls", namespace="django-lightweight-queue"
+            ),
+        )
+    ]
 ```
 
 This backend may require an extra setting if your debug site is not on localhost:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ backends are great candidates for community contributions.
 
 ## Basic Usage
 
+Start by adding `django_lightweight_queue` to your `INSTALLED_APPS`:
+
+```python
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    ...,
+    "django_lightweight_queue",
+]
+```
+
+After that, define your task in any file you want:
+
 ```python
 import time
 from django_lightweight_queue import task
@@ -67,12 +80,51 @@ present in the specified file are inherited from the global configuration.
 
 There are four built-in backends:
 
-| Backend        | Type        | Description                                                                                                                                                                       |
-| -------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Synchronous    | Development | Executes the task inline, without any actual queuing.                                                                                                                             |
-| Redis          | Production  | Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.                                                                                               |
-| Reliable Redis | Production  | Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.                      |
-| Debug Web      | Debugging   | Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks. |
+### Synchronous (Development backend)
+
+`django_lightweight_queue.backends.synchronous.SynchronousBackend`
+
+Executes the task inline, without any actual queuing.
+
+### Redis (Production backend)
+
+`django_lightweight_queue.backends.redis.RedisBackend`
+
+Executes tasks at-most-once using [Redis][redis] for storage of the enqueued tasks.
+
+### Reliable Redis (Production backend)
+
+`django_lightweight_queue.backends.reliable_redis.ReliableRedisBackend`
+
+Executes tasks at-least-once using [Redis][redis] for storage of the enqueued tasks (subject to Redis consistency). Does not guarantee the task _completes_.
+
+### Debug Web (Debug backend)
+
+`django_lightweight_queue.backends.debug_web.DebugWebBackend`
+
+Instead of running jobs it prints the url to a view that can be used to run a task in a transaction which will be rolled back. This is useful for debugging and optimising tasks.
+
+Use this to append the appropriate URLs to the bottom of your root `urls.py`:
+
+```python
+from django.conf import settings
+from django.urls import path, include
+
+urlpatterns = [
+    ...
+]
+
+if "debug_web" in settings.LIGHTWEIGHT_QUEUE_BACKEND:
+    from django_lightweight_queue import urls as dlq_urls
+    urlpatterns += [path("", include(dlq_urls))]
+```
+
+This backend may require an extra setting if your debug site is not on localhost:
+
+```python
+# defaults to http://localhost:8000
+LIGHTWEIGHT_QUEUE_SITE_URL = "http://example.com:8000"
+```
 
 [redis]: https://redis.io/
 


### PR DESCRIPTION
Expanding from https://github.com/thread/django-lightweight-queue/pull/61

Just the readme changes from #61 - specific changes are the addition of the installation into `INSTALLED_APPS`, updated information on the backends, and specific implementation notes for debug web.