### PR TITLE
Use importlib for loading extra configuration

### DIFF
--- a/django_lightweight_queue/utils.py
+++ b/django_lightweight_queue/utils.py
@@ -1,8 +1,8 @@
-import imp
 import time
 import datetime
 import warnings
 import importlib
+import importlib.util
 from typing import (
     Any,
     Set,
@@ -33,7 +33,10 @@ FIVE_SECONDS = datetime.timedelta(seconds=5)
 
 
 def load_extra_config(file_path: str) -> None:
-    extra_settings = imp.load_source('extra_settings', file_path)
+    # Based on https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+    spec = importlib.util.spec_from_file_location('extra_settings', file_path)
+    extra_settings = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(extra_settings)  # type: ignore[union-attr]
 
     def get_setting_names(module: object) -> Set[str]:
         return set(name for name in dir(module) if name.isupper())

--- a/tests/_demo_extra_config.py
+++ b/tests/_demo_extra_config.py
@@ -1,0 +1,7 @@
+from django_lightweight_queue.types import QueueName
+
+LIGHTWEIGHT_QUEUE_BACKEND_OVERRIDES = {
+    QueueName('test-queue'): 'tests.test_extra_config.TestBackend',
+}
+
+LIGHTWEIGHT_QUEUE_REDIS_PASSWORD = 'a very bad password'

--- a/tests/_demo_extra_config_falsey.py
+++ b/tests/_demo_extra_config_falsey.py
@@ -1,0 +1,4 @@
+# Override to falsey values
+LIGHTWEIGHT_QUEUE_REDIS_PASSWORD = None
+
+LIGHTWEIGHT_QUEUE_ATOMIC_JOBS = False

--- a/tests/_demo_extra_config_unexpected.py
+++ b/tests/_demo_extra_config_unexpected.py
@@ -1,0 +1,4 @@
+
+LIGHTWEIGHT_QUEUE_REDIS_PASSWORD = 'expected'
+
+NOT_REDIS_PASSWORD = 'unexpected'

--- a/tests/test_extra_config.py
+++ b/tests/test_extra_config.py
@@ -1,0 +1,60 @@
+import importlib
+from typing import Optional
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from django_lightweight_queue import app_settings
+from django_lightweight_queue.job import Job
+from django_lightweight_queue.types import QueueName, WorkerNumber
+from django_lightweight_queue.utils import get_backend, load_extra_config
+from django_lightweight_queue.backends.base import BaseBackend
+
+TESTS_DIR = Path(__file__).parent
+
+
+class TestBackend(BaseBackend):
+    def enqueue(self, job: Job, queue: QueueName) -> None:
+        pass
+
+    def dequeue(self, queue: QueueName, worker_num: WorkerNumber, timeout: int) -> Optional[Job]:
+        pass
+
+    def length(self, queue: QueueName) -> int:
+        pass
+
+
+class ExtraConfigTests(SimpleTestCase):
+    def setUp(self) -> None:
+        get_backend.cache_clear()
+        super().setUp()
+
+    def tearDown(self) -> None:
+        importlib.reload(app_settings)
+        get_backend.cache_clear()
+        super().tearDown()
+
+    def test_updates_configuration(self) -> None:
+        load_extra_config(str(TESTS_DIR / '_demo_extra_config.py'))
+
+        backend = get_backend('test-queue')
+        self.assertIsInstance(backend, TestBackend)
+
+        self.assertEqual('a very bad password', app_settings.REDIS_PASSWORD)
+
+    def test_warns_about_unexpected_settings(self) -> None:
+        with self.assertWarnsRegex(Warning, r'Ignoring unexpected setting.+\bNOT_REDIS_PASSWORD\b'):
+            load_extra_config(str(TESTS_DIR / '_demo_extra_config_unexpected.py'))
+
+        self.assertEqual('expected', app_settings.REDIS_PASSWORD)
+
+    def test_updates_configuration_with_falsey_values(self) -> None:
+        load_extra_config(str(TESTS_DIR / '_demo_extra_config.py'))
+        load_extra_config(str(TESTS_DIR / '_demo_extra_config_falsey.py'))
+
+        self.assertIsNone(app_settings.REDIS_PASSWORD)
+        self.assertFalse(app_settings.ATOMIC_JOBS)
+
+    def test_rejects_missing_file(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            load_extra_config(str(TESTS_DIR / '_no_such_file.py'))


### PR DESCRIPTION
This replaces the remaining use of the deprecated `imp` module with `importlib` & adds some tests for the extra configuration loading behaviour.