### PR TITLE
Limit impact of reliable backend startup routine on Redis load

### DIFF
--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -55,7 +55,7 @@ class ReliableRedisBackend(BackendWithDeduplicate, BackendWithPauseResume):
         # Without this the startup process can end up racing against workers on
         # other machines which are validly re-populating their processing queues
         # as they work on jobs.
-        current_processing_queue_keys = set(self.client.keys(pattern))
+        current_processing_queue_keys = set(self.client.scan_iter(pattern))
         expected_processing_queue_keys = set(
             self._processing_key(queue, worker_number).encode()
             for worker_number in get_worker_numbers(queue)


### PR DESCRIPTION
As the usage has grown we've started seeing some impact form `KEYS` being
blocking and holding up the Redis instance. This is made worse by the
fact than on startup many workers will be attempting this at the same
time.

This change moves to using the non blocking `SCAN` instead. The main
concern here is that the collection of keys can change during iteration
however for this use case I think this is fine as the 2 changes we can
expect are:

- A key goes away: this would be another startup routine removing a
  worker key after re-enqueuing its job so should be safe.
- A key appearing: this would be a new worker coming online and should
  not be impacting the recovery mechanism as it should also be part of
  `expected_processing_queue_keys`.

---

Relying on small scope + existing tests here. 

--- 

We've discussed some other things we could do here; specifically doing this less which could be:

- Only run this on worker 0 of any given queue
- Do some locking to avoid thundering all machines doing this at once

But for now let's see what the SCAN change brings and iterate from there.
