### PR TITLE
Support specifying the Redis Database to use on the host

### DIFF
--- a/django_lightweight_queue/app_settings.py
+++ b/django_lightweight_queue/app_settings.py
@@ -43,6 +43,7 @@ IGNORE_APPS = setting('IGNORE_APPS', ())  # type: Sequence[str]
 REDIS_HOST = setting('REDIS_HOST', '127.0.0.1')  # type: str
 REDIS_PORT = setting('REDIS_PORT', 6379)  # type: int
 REDIS_PASSWORD = setting('REDIS_PASSWORD', None)  # type: Optional[str]
+REDIS_DATABASE = setting('REDIS_DATABASE', 0)  # type: int
 REDIS_PREFIX = setting('REDIS_PREFIX', '')  # type: str
 
 ENABLE_PROMETHEUS = setting('ENABLE_PROMETHEUS', False)  # type: bool

--- a/django_lightweight_queue/backends/redis.py
+++ b/django_lightweight_queue/backends/redis.py
@@ -20,6 +20,7 @@ class RedisBackend(BackendWithPauseResume, BackendWithClear):
             host=app_settings.REDIS_HOST,
             port=app_settings.REDIS_PORT,
             password=app_settings.REDIS_PASSWORD,
+            db=app_settings.REDIS_DATABASE,
         )
 
     def enqueue(self, job: Job, queue: QueueName) -> None:

--- a/django_lightweight_queue/backends/reliable_redis.py
+++ b/django_lightweight_queue/backends/reliable_redis.py
@@ -46,6 +46,7 @@ class ReliableRedisBackend(BackendWithClear, BackendWithDeduplicate, BackendWith
             host=app_settings.REDIS_HOST,
             port=app_settings.REDIS_PORT,
             password=app_settings.REDIS_PASSWORD,
+            db=app_settings.REDIS_DATABASE,
         )
 
     def startup(self, queue: QueueName) -> None:


### PR DESCRIPTION
Database zero is the default that the Python redis client uses, so default to that to avoid breakage. Since DLQ uses `KEYS` it's potentially useful to be able to run it in its own database as that may limit the performance concerns around the `KEYS` command.