### PR TITLE
Update actions/checkout to v4 for latest NodeJS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Poetry
         run: pipx install poetry==1.3.2
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Poetry
         run: pipx install poetry==1.3.2
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Poetry
         run: pipx install poetry==1.3.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,11 @@ jobs:
     needs:
       - run-checks
     steps:
-      # Using v2 or later strips tag annotations https://github.com/actions/checkout/issues/290
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+
+      # work around actions/checkout stripping annotations https://github.com/actions/checkout/issues/290
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Set up Poetry
         run: pipx install poetry==1.3.2


### PR DESCRIPTION
This avoids warnings from GitHub about legacy NodeJS.